### PR TITLE
[feat] 닉네임 조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/auth/facade/AuthFacade.java
+++ b/src/main/java/org/festimate/team/auth/facade/AuthFacade.java
@@ -27,7 +27,7 @@ public class AuthFacade {
         }
 
         TokenResponse response = authService.login(userId);
-        userService.updateRefreshToken(response.userId(), response.accessToken());
+        userService.updateRefreshToken(response.userId(), response.refreshToken());
 
         return response;
     }

--- a/src/main/java/org/festimate/team/auth/facade/AuthFacade.java
+++ b/src/main/java/org/festimate/team/auth/facade/AuthFacade.java
@@ -26,10 +26,10 @@ public class AuthFacade {
             return new TokenResponse(null, accessToken, null);
         }
 
-        TokenResponse response = authService.login(userId, accessToken);
+        TokenResponse response = authService.login(userId);
         userService.updateRefreshToken(response.userId(), response.accessToken());
 
-        return authService.login(userId, accessToken);
+        return response;
     }
 
     public TokenResponse signUp(String token, SignUpRequest request) {

--- a/src/main/java/org/festimate/team/auth/jwt/JwtProvider.java
+++ b/src/main/java/org/festimate/team/auth/jwt/JwtProvider.java
@@ -1,33 +1,58 @@
 package org.festimate.team.auth.jwt;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtProvider {
     private final JwtProperties jwtProperties;
 
-    public String createAccessToken(String userId) {
+    private static final String USER_ID = "userId";
+
+    public String createAccessToken(Long userId) {
         return createToken(userId, jwtProperties.getAccessExpiration());
     }
 
-    public String createRefreshToken(String userId) {
+    public String createRefreshToken(Long userId) {
         return createToken(userId, jwtProperties.getRefreshExpiration());
     }
 
-    private String createToken(String userId, long expirationTime) {
+    private String createToken(Long userId, long expirationTime) {
+        SecretKey secretKey = getSecretKey();
+
         return Jwts.builder()
-                .setSubject(userId)
+                .setSubject(userId.toString())
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expirationTime))
-                .signWith(Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .claim(USER_ID, userId)
+                .signWith(secretKey)
                 .compact();
+    }
+
+    public Long parseTokenAndGetUserId(String token) {
+        SecretKey secretKey = getSecretKey();
+
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.get(USER_ID, Long.class);
+    }
+
+    private SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(
+                jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/org/festimate/team/auth/service/AuthService.java
+++ b/src/main/java/org/festimate/team/auth/service/AuthService.java
@@ -3,7 +3,7 @@ package org.festimate.team.auth.service;
 import org.festimate.team.user.dto.TokenResponse;
 
 public interface AuthService {
-    TokenResponse login(Long userId, String accessToken);
+    TokenResponse login(Long userId);
 
     TokenResponse signUp(Long userId);
 

--- a/src/main/java/org/festimate/team/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/festimate/team/auth/service/impl/AuthServiceImpl.java
@@ -14,9 +14,9 @@ public class AuthServiceImpl implements AuthService {
     private final JwtProvider jwtProvider;
 
     @Transactional
-    public TokenResponse login(Long userId, String accessToken) {
-        String newAccessToken = jwtProvider.createAccessToken(userId.toString());
-        String newRefreshToken = jwtProvider.createRefreshToken(userId.toString());
+    public TokenResponse login(Long userId) {
+        String newAccessToken = jwtProvider.createAccessToken(userId);
+        String newRefreshToken = jwtProvider.createRefreshToken(userId);
 
         return new TokenResponse(userId, newAccessToken, newRefreshToken);
     }
@@ -25,8 +25,8 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public TokenResponse signUp(Long userId) {
 
-        String accessToken = jwtProvider.createAccessToken(userId.toString());
-        String refreshToken = jwtProvider.createRefreshToken(userId.toString());
+        String accessToken = jwtProvider.createAccessToken(userId);
+        String refreshToken = jwtProvider.createRefreshToken(userId);
 
         return new TokenResponse(userId, accessToken, refreshToken);
     }

--- a/src/main/java/org/festimate/team/user/controller/UserController.java
+++ b/src/main/java/org/festimate/team/user/controller/UserController.java
@@ -3,6 +3,7 @@ package org.festimate.team.user.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.festimate.team.auth.facade.AuthFacade;
+import org.festimate.team.auth.jwt.JwtProvider;
 import org.festimate.team.common.response.ApiResponse;
 import org.festimate.team.common.response.ResponseBuilder;
 import org.festimate.team.user.dto.SignUpRequest;
@@ -21,6 +22,7 @@ public class UserController {
     private final UserService userService;
     private final NicknameValidator nicknameValidator;
     private final AuthFacade authFacade;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/validate/nickname")
     public ResponseEntity<ApiResponse<Void>> validateNickname(@RequestParam("nickname") String nickname) {
@@ -43,5 +45,14 @@ public class UserController {
     ) {
         TokenResponse response = authFacade.signUp(token, request);
         return ResponseBuilder.created(response);
+    }
+
+    @GetMapping("/nickname")
+    public ResponseEntity<ApiResponse<String>> getNickname(
+            @RequestHeader("Authorization") String accessToken
+    ) {
+        Long userId = jwtProvider.parseTokenAndGetUserId(accessToken);
+        String nickName = userService.getUserNickname(userId);
+        return ResponseBuilder.ok(nickName);
     }
 }

--- a/src/main/java/org/festimate/team/user/repository/UserRepository.java
+++ b/src/main/java/org/festimate/team/user/repository/UserRepository.java
@@ -2,11 +2,15 @@ package org.festimate.team.user.repository;
 
 import org.festimate.team.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsUserByNickname(String nickname);
+
+    @Query("SELECT u.nickname FROM User u WHERE u.userId = :userId")
+    String findNicknameByUserId(Long userId);
 
     Optional<User> findByPlatformId(String platformId);
 }

--- a/src/main/java/org/festimate/team/user/service/UserService.java
+++ b/src/main/java/org/festimate/team/user/service/UserService.java
@@ -10,4 +10,6 @@ public interface UserService {
     void updateRefreshToken(Long userId, String refreshToken);
 
     Long saveUser(SignUpRequest request, String platformId);
+
+    String getUserNickname(Long userId);
 }

--- a/src/main/java/org/festimate/team/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/festimate/team/user/service/impl/UserServiceImpl.java
@@ -41,10 +41,9 @@ public class UserServiceImpl implements UserService {
                 .platform(request.platform())
                 .build();
 
-        userRepository.save(user);
         log.info("Checking user Info: {}", user);
 
-        return user.getUserId();
+        return userRepository.save(user).getUserId();
     }
 
     @Override
@@ -59,6 +58,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public void updateRefreshToken(Long userId, String refreshToken) {
         User user = userRepository.findById(userId).orElseThrow(() -> new FestimateException(ResponseError.USER_NOT_FOUND));
         user.updateRefreshToken(refreshToken);

--- a/src/main/java/org/festimate/team/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/festimate/team/user/service/impl/UserServiceImpl.java
@@ -48,6 +48,12 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public String getUserNickname(Long userId) {
+        findByIdOrThrow(userId);
+        return userRepository.findNicknameByUserId(userId);
+    }
+
+    @Override
     public Long getUserIdByPlatformId(String platformId) {
         return userRepository.findByPlatformId(platformId).map(User::getUserId).orElse(null);
     }
@@ -59,8 +65,8 @@ public class UserServiceImpl implements UserService {
         userRepository.save(user);
     }
 
-    private User findByIdOrThrow(Long userId) {
-        return userRepository.findById(userId)
+    private void findByIdOrThrow(Long userId) {
+        userRepository.findById(userId)
                 .orElseThrow(() -> new FestimateException(ResponseError.USER_NOT_FOUND));
     }
 


### PR DESCRIPTION
## 📌 PR 제목
[feat] 닉네임 조회 API 기능 구현

## 📌 PR 내용
- 메인 화면의 닉네임 조회 API 기능을 구현했습니다.

## 🛠 작업 내용
| 화면     | 메인                                                                 | 나의 페이지                                                              |
|----------|----------------------------------------------------------------------|---------------------------------------------------------------------------|
| 이미지   | ![Image](https://github.com/user-attachments/assets/371c0d47-a517-41ef-b54d-9d261d9b7033) | ![Image](https://github.com/user-attachments/assets/45064433-8d0f-4175-b93a-7d6336bdeab0) |

- [x] 메인 화면의 닉네임 조회 API 기능 구현

## 🔍 관련 이슈
Closes #18 

## 📸 스크린샷 (Optional)
<img width="671" alt="image" src="https://github.com/user-attachments/assets/a2f88348-0a9d-4f87-bd26-719e7a129710" />

## 📚 레퍼런스 (Optional)
N/A