### PR TITLE
[feat] #22 페스티벌 생성 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/auth/service/AuthService.java
+++ b/src/main/java/org/festimate/team/auth/service/AuthService.java
@@ -3,8 +3,6 @@ package org.festimate.team.auth.service;
 import org.festimate.team.user.dto.TokenResponse;
 
 public interface AuthService {
-    TokenResponse login(Long userId);
-
-    TokenResponse signUp(Long userId);
+    TokenResponse generateTokens(Long userId);
 
 }

--- a/src/main/java/org/festimate/team/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/festimate/team/auth/service/impl/AuthServiceImpl.java
@@ -13,21 +13,12 @@ public class AuthServiceImpl implements AuthService {
 
     private final JwtProvider jwtProvider;
 
+    @Override
     @Transactional
-    public TokenResponse login(Long userId) {
+    public TokenResponse generateTokens(Long userId) {
         String newAccessToken = jwtProvider.createAccessToken(userId);
         String newRefreshToken = jwtProvider.createRefreshToken(userId);
 
         return new TokenResponse(userId, newAccessToken, newRefreshToken);
-    }
-
-    @Override
-    @Transactional
-    public TokenResponse signUp(Long userId) {
-
-        String accessToken = jwtProvider.createAccessToken(userId);
-        String refreshToken = jwtProvider.createRefreshToken(userId);
-
-        return new TokenResponse(userId, accessToken, refreshToken);
     }
 }

--- a/src/main/java/org/festimate/team/facade/AuthFacade.java
+++ b/src/main/java/org/festimate/team/facade/AuthFacade.java
@@ -1,4 +1,4 @@
-package org.festimate.team.auth.facade;
+package org.festimate.team.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.festimate.team.auth.infra.KakaoApiClient;
@@ -26,10 +26,7 @@ public class AuthFacade {
             return new TokenResponse(null, accessToken, null);
         }
 
-        TokenResponse response = authService.login(userId);
-        userService.updateRefreshToken(response.userId(), response.refreshToken());
-
-        return response;
+        return generateRefreshToken(userId);
     }
 
     public TokenResponse signUp(String token, SignUpRequest request) {
@@ -38,6 +35,13 @@ public class AuthFacade {
         userService.duplicateNickname(request.nickName());
         Long userId = userService.saveUser(request, platformId);
 
-        return authService.signUp(userId);
+        return generateRefreshToken(userId);
+    }
+
+    private TokenResponse generateRefreshToken(Long userId) {
+        TokenResponse response = authService.generateTokens(userId);
+        userService.updateRefreshToken(response.userId(), response.refreshToken());
+
+        return response;
     }
 }

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -1,0 +1,24 @@
+package org.festimate.team.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.festimate.team.festival.dto.FestivalRequest;
+import org.festimate.team.festival.dto.FestivalResponse;
+import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.festival.service.FestivalService;
+import org.festimate.team.user.entity.User;
+import org.festimate.team.user.service.UserService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FestivalFacade {
+    private final UserService userService;
+    private final FestivalService festivalService;
+
+    public FestivalResponse createFestival(Long userId, FestivalRequest request) {
+        User host = userService.getUserById(userId);
+        Festival festival = festivalService.createFestival(host, request);
+
+        return FestivalResponse.from(festival.getFestivalId(), festival.getInviteCode());
+    }
+}

--- a/src/main/java/org/festimate/team/festival/controller/FestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/FestivalController.java
@@ -1,35 +1,50 @@
 package org.festimate.team.festival.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.festimate.team.auth.jwt.JwtProvider;
+import org.festimate.team.common.response.ApiResponse;
+import org.festimate.team.common.response.ResponseBuilder;
+import org.festimate.team.festival.dto.FestivalRequest;
+import org.festimate.team.festival.dto.FestivalResponse;
 import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.festival.entity.Role;
 import org.festimate.team.festival.service.FestivalService;
+import org.festimate.team.user.entity.User;
+import org.festimate.team.user.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/festivals")
+@RequestMapping("/api/v1/festival")
 @RequiredArgsConstructor
 public class FestivalController {
 
     private final FestivalService festivalService;
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
 
-    // 페스티벌 등록
     @PostMapping
-    public ResponseEntity<Festival> createFestival(@RequestBody Festival festival) {
-        Festival savedFestival = festivalService.createFestival(festival);
-        return ResponseEntity.ok(savedFestival);
+    public ResponseEntity<ApiResponse<FestivalResponse>> createFestival(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestBody FestivalRequest request
+    ) {
+        Long userId = jwtProvider.parseTokenAndGetUserId(accessToken);
+        User user = userService.getUserById(userId);
+
+        Festival festival = festivalService.createFestival(request);
+        festivalService.applyFestival(user, festival, Role.HOST);
+
+        return ResponseBuilder.created(FestivalResponse.from(festival.getFestivalId(), festival.getInviteCode()));
     }
 
-    // 초대 코드로 페스티벌 조회
     @GetMapping("/{inviteCode}")
     public ResponseEntity<Festival> getFestivalByInviteCode(@PathVariable String inviteCode) {
         Festival festival = festivalService.getFestivalByInviteCode(inviteCode);
         return ResponseEntity.ok(festival);
     }
 
-    // 전체 페스티벌 목록 조회
     @GetMapping
     public ResponseEntity<List<Festival>> getAllFestivals() {
         List<Festival> festivals = festivalService.getAllFestivals();

--- a/src/main/java/org/festimate/team/festival/controller/FestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/FestivalController.java
@@ -4,13 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.festimate.team.auth.jwt.JwtProvider;
 import org.festimate.team.common.response.ApiResponse;
 import org.festimate.team.common.response.ResponseBuilder;
+import org.festimate.team.facade.FestivalFacade;
 import org.festimate.team.festival.dto.FestivalRequest;
 import org.festimate.team.festival.dto.FestivalResponse;
 import org.festimate.team.festival.entity.Festival;
-import org.festimate.team.festival.entity.Role;
 import org.festimate.team.festival.service.FestivalService;
-import org.festimate.team.user.entity.User;
-import org.festimate.team.user.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,8 +20,8 @@ import java.util.List;
 public class FestivalController {
 
     private final FestivalService festivalService;
+    private final FestivalFacade festivalFacade;
     private final JwtProvider jwtProvider;
-    private final UserService userService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<FestivalResponse>> createFestival(
@@ -31,12 +29,9 @@ public class FestivalController {
             @RequestBody FestivalRequest request
     ) {
         Long userId = jwtProvider.parseTokenAndGetUserId(accessToken);
-        User user = userService.getUserById(userId);
+        FestivalResponse response = festivalFacade.createFestival(userId, request);
 
-        Festival festival = festivalService.createFestival(request);
-        festivalService.applyFestival(user, festival, Role.HOST);
-
-        return ResponseBuilder.created(FestivalResponse.from(festival.getFestivalId(), festival.getInviteCode()));
+        return ResponseBuilder.created(response);
     }
 
     @GetMapping("/{inviteCode}")

--- a/src/main/java/org/festimate/team/festival/dto/FestivalRequest.java
+++ b/src/main/java/org/festimate/team/festival/dto/FestivalRequest.java
@@ -1,0 +1,12 @@
+package org.festimate.team.festival.dto;
+
+import org.festimate.team.festival.entity.Category;
+
+import java.time.LocalDate;
+
+public record FestivalRequest(
+        String title,
+        Category category,
+        LocalDate startDate,
+        LocalDate endDate
+){}

--- a/src/main/java/org/festimate/team/festival/dto/FestivalResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/FestivalResponse.java
@@ -1,0 +1,10 @@
+package org.festimate.team.festival.dto;
+
+public record FestivalResponse(
+        Long festivalId,
+        String inviteCode
+) {
+    public static FestivalResponse from(Long festivalId, String inviteCode) {
+        return new FestivalResponse(festivalId, inviteCode);
+    }
+}

--- a/src/main/java/org/festimate/team/festival/entity/Category.java
+++ b/src/main/java/org/festimate/team/festival/entity/Category.java
@@ -1,7 +1,7 @@
 package org.festimate.team.festival.entity;
 
 public enum Category {
-    CONCERT,
-    FESTIVAL,
+    LIFE,
+    MUSIC,
     SCHOOL;
 }

--- a/src/main/java/org/festimate/team/festival/entity/Festival.java
+++ b/src/main/java/org/festimate/team/festival/entity/Festival.java
@@ -9,7 +9,7 @@ import org.festimate.team.common.entity.BaseTimeEntity;
 import org.festimate.team.matching.entity.Matching;
 import org.hibernate.annotations.DynamicUpdate;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -31,10 +31,10 @@ public class Festival extends BaseTimeEntity {
     private Category category;
 
     @Column(nullable = false)
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @Column(nullable = false)
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     @Column(nullable = false, unique = true)
     private String inviteCode;
@@ -46,7 +46,7 @@ public class Festival extends BaseTimeEntity {
     private List<Matching> matchings;
 
     @Builder
-    public Festival(String title, Category category, LocalDateTime startDate, LocalDateTime endDate, String inviteCode) {
+    public Festival(String title, Category category, LocalDate startDate, LocalDate endDate, String inviteCode) {
         this.title = title;
         this.category = category;
         this.startDate = startDate;

--- a/src/main/java/org/festimate/team/festival/entity/Festival.java
+++ b/src/main/java/org/festimate/team/festival/entity/Festival.java
@@ -21,7 +21,7 @@ public class Festival extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer festivalId;
+    private Long festivalId;
 
     @Column(nullable = false)
     private String title;

--- a/src/main/java/org/festimate/team/festival/entity/Festival.java
+++ b/src/main/java/org/festimate/team/festival/entity/Festival.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.festimate.team.common.entity.BaseTimeEntity;
 import org.festimate.team.matching.entity.Matching;
+import org.festimate.team.user.entity.User;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
@@ -22,6 +23,10 @@ public class Festival extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long festivalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id", nullable = false)
+    private User host;
 
     @Column(nullable = false)
     private String title;
@@ -46,7 +51,8 @@ public class Festival extends BaseTimeEntity {
     private List<Matching> matchings;
 
     @Builder
-    public Festival(String title, Category category, LocalDate startDate, LocalDate endDate, String inviteCode) {
+    public Festival(User host, String title, Category category, LocalDate startDate, LocalDate endDate, String inviteCode) {
+        this.host = host;
         this.title = title;
         this.category = category;
         this.startDate = startDate;

--- a/src/main/java/org/festimate/team/festival/entity/Participant.java
+++ b/src/main/java/org/festimate/team/festival/entity/Participant.java
@@ -40,7 +40,10 @@ public class Participant extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private TypeResult typeResult;
 
+    @Column(nullable = false)
     private String introduction;
+
+    private String message;
 
     @OneToMany(mappedBy = "participant")
     private List<Point> points;
@@ -52,11 +55,12 @@ public class Participant extends BaseTimeEntity {
     private List<Matching> matchingsAsTarget;
 
     @Builder
-    public Participant(User user, Festival festival, Role role, TypeResult typeResult, String introduction) {
+    public Participant(User user, Festival festival, Role role, TypeResult typeResult, String introduction, String message) {
         this.user = user;
         this.festival = festival;
         this.role = role;
         this.typeResult = typeResult;
         this.introduction = introduction;
+        this.message = message;
     }
 }

--- a/src/main/java/org/festimate/team/festival/repository/FestivalRepository.java
+++ b/src/main/java/org/festimate/team/festival/repository/FestivalRepository.java
@@ -4,5 +4,7 @@ import org.festimate.team.festival.entity.Festival;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FestivalRepository extends JpaRepository<Festival, Integer> {
-    Festival findByInviteCode(String inviteCode);  // 초대 코드로 조회하는 메서드 추가
+    boolean existsByInviteCode(String inviteCode);
+
+    Festival findByInviteCode(String inviteCode);
 }

--- a/src/main/java/org/festimate/team/festival/repository/ParticipantRepository.java
+++ b/src/main/java/org/festimate/team/festival/repository/ParticipantRepository.java
@@ -1,0 +1,7 @@
+package org.festimate.team.festival.repository;
+
+import org.festimate.team.festival.entity.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Integer> {
+}

--- a/src/main/java/org/festimate/team/festival/service/FestivalService.java
+++ b/src/main/java/org/festimate/team/festival/service/FestivalService.java
@@ -1,72 +1,16 @@
 package org.festimate.team.festival.service;
 
-import lombok.RequiredArgsConstructor;
 import org.festimate.team.festival.dto.FestivalRequest;
 import org.festimate.team.festival.entity.Festival;
-import org.festimate.team.festival.entity.Participant;
-import org.festimate.team.festival.entity.Role;
-import org.festimate.team.festival.entity.TypeResult;
-import org.festimate.team.festival.repository.FestivalRepository;
-import org.festimate.team.festival.repository.ParticipantRepository;
 import org.festimate.team.user.entity.User;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Random;
 
-@Service
-@RequiredArgsConstructor
-public class FestivalService {
+public interface FestivalService {
+    Festival createFestival(User host, FestivalRequest request);
 
-    private final FestivalRepository festivalRepository;
-    private final ParticipantRepository participantRepository;
+    Festival getFestivalByInviteCode(String inviteCode);
 
-    @Transactional
-    public Festival createFestival(FestivalRequest request) {
-        String inviteCode = generateUniqueInviteCode();
+    List<Festival> getAllFestivals();
 
-        Festival festival = Festival.builder()
-                .title(request.title())
-                .category(request.category())
-                .startDate(request.startDate())
-                .endDate(request.endDate())
-                .inviteCode(inviteCode)
-                .build();
-
-        return festivalRepository.save(festival);
-    }
-
-    @Transactional
-    public Participant applyFestival(User user, Festival festival, Role role) {
-        Participant participant = Participant.builder()
-                .user(user)
-                .festival(festival)
-                .role(role)
-                .typeResult(TypeResult.HEALING)
-                .introduction("")
-                .message("")
-                .build();
-
-        return participantRepository.save(participant);
-    }
-
-    @Transactional(readOnly = true)
-    public Festival getFestivalByInviteCode(String inviteCode) {
-        return festivalRepository.findByInviteCode(inviteCode);
-    }
-
-    @Transactional(readOnly = true)
-    public List<Festival> getAllFestivals() {
-        return festivalRepository.findAll();
-    }
-
-    private String generateUniqueInviteCode() {
-        Random random = new Random();
-        String inviteCode;
-        do {
-            inviteCode = String.valueOf(100000 + random.nextInt(900000));
-        } while (festivalRepository.existsByInviteCode(inviteCode));
-        return inviteCode;
-    }
 }

--- a/src/main/java/org/festimate/team/festival/service/FestivalService.java
+++ b/src/main/java/org/festimate/team/festival/service/FestivalService.java
@@ -1,22 +1,54 @@
 package org.festimate.team.festival.service;
 
 import lombok.RequiredArgsConstructor;
+import org.festimate.team.festival.dto.FestivalRequest;
 import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.festival.entity.Participant;
+import org.festimate.team.festival.entity.Role;
+import org.festimate.team.festival.entity.TypeResult;
 import org.festimate.team.festival.repository.FestivalRepository;
+import org.festimate.team.festival.repository.ParticipantRepository;
+import org.festimate.team.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
 public class FestivalService {
 
     private final FestivalRepository festivalRepository;
+    private final ParticipantRepository participantRepository;
 
     @Transactional
-    public Festival createFestival(Festival festival) {
+    public Festival createFestival(FestivalRequest request) {
+        String inviteCode = generateUniqueInviteCode();
+
+        Festival festival = Festival.builder()
+                .title(request.title())
+                .category(request.category())
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .inviteCode(inviteCode)
+                .build();
+
         return festivalRepository.save(festival);
+    }
+
+    @Transactional
+    public Participant applyFestival(User user, Festival festival, Role role) {
+        Participant participant = Participant.builder()
+                .user(user)
+                .festival(festival)
+                .role(role)
+                .typeResult(TypeResult.HEALING)
+                .introduction("")
+                .message("")
+                .build();
+
+        return participantRepository.save(participant);
     }
 
     @Transactional(readOnly = true)
@@ -27,5 +59,14 @@ public class FestivalService {
     @Transactional(readOnly = true)
     public List<Festival> getAllFestivals() {
         return festivalRepository.findAll();
+    }
+
+    private String generateUniqueInviteCode() {
+        Random random = new Random();
+        String inviteCode;
+        do {
+            inviteCode = String.valueOf(100000 + random.nextInt(900000));
+        } while (festivalRepository.existsByInviteCode(inviteCode));
+        return inviteCode;
     }
 }

--- a/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
+++ b/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
@@ -1,0 +1,57 @@
+package org.festimate.team.festival.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.festimate.team.festival.dto.FestivalRequest;
+import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.festival.repository.FestivalRepository;
+import org.festimate.team.festival.service.FestivalService;
+import org.festimate.team.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class FestivalServiceImpl implements FestivalService {
+
+    private final FestivalRepository festivalRepository;
+
+    @Override
+    @Transactional
+    public Festival createFestival(User host, FestivalRequest request) {
+        String inviteCode = generateUniqueInviteCode();
+
+        Festival festival = Festival.builder()
+                .host(host)
+                .title(request.title())
+                .category(request.category())
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .inviteCode(inviteCode)
+                .build();
+
+        return festivalRepository.save(festival);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Festival getFestivalByInviteCode(String inviteCode) {
+        return festivalRepository.findByInviteCode(inviteCode);
+    }
+
+    @Override
+    public List<Festival> getAllFestivals() {
+        return festivalRepository.findAll();
+    }
+
+    private String generateUniqueInviteCode() {
+        Random random = new Random();
+        String inviteCode;
+        do {
+            inviteCode = String.valueOf(100000 + random.nextInt(900000));
+        } while (festivalRepository.existsByInviteCode(inviteCode));
+        return inviteCode;
+    }
+}

--- a/src/main/java/org/festimate/team/user/controller/UserController.java
+++ b/src/main/java/org/festimate/team/user/controller/UserController.java
@@ -2,7 +2,7 @@ package org.festimate.team.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.festimate.team.auth.facade.AuthFacade;
+import org.festimate.team.facade.AuthFacade;
 import org.festimate.team.auth.jwt.JwtProvider;
 import org.festimate.team.common.response.ApiResponse;
 import org.festimate.team.common.response.ResponseBuilder;

--- a/src/main/java/org/festimate/team/user/repository/UserRepository.java
+++ b/src/main/java/org/festimate/team/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     String findNicknameByUserId(Long userId);
 
     Optional<User> findByPlatformId(String platformId);
+
+    Optional<User> getUserByUserId(Long userId);
 }

--- a/src/main/java/org/festimate/team/user/service/UserService.java
+++ b/src/main/java/org/festimate/team/user/service/UserService.java
@@ -1,6 +1,7 @@
 package org.festimate.team.user.service;
 
 import org.festimate.team.user.dto.SignUpRequest;
+import org.festimate.team.user.entity.User;
 
 public interface UserService {
     void duplicateNickname(String nickname);
@@ -12,4 +13,6 @@ public interface UserService {
     Long saveUser(SignUpRequest request, String platformId);
 
     String getUserNickname(Long userId);
+
+    User getUserById(Long userId);
 }

--- a/src/main/java/org/festimate/team/user/service/UserService.java
+++ b/src/main/java/org/festimate/team/user/service/UserService.java
@@ -15,4 +15,6 @@ public interface UserService {
     String getUserNickname(Long userId);
 
     User getUserById(Long userId);
+
+    void findByIdOrThrow(Long userId);
 }

--- a/src/main/java/org/festimate/team/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/festimate/team/user/service/impl/UserServiceImpl.java
@@ -53,6 +53,11 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public User getUserById(Long userId) {
+        return userRepository.getUserByUserId(userId).orElseThrow(() -> new FestimateException(ResponseError.USER_NOT_FOUND));
+    }
+
+    @Override
     public Long getUserIdByPlatformId(String platformId) {
         return userRepository.findByPlatformId(platformId).map(User::getUserId).orElse(null);
     }

--- a/src/main/java/org/festimate/team/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/festimate/team/user/service/impl/UserServiceImpl.java
@@ -54,7 +54,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public User getUserById(Long userId) {
-        return userRepository.getUserByUserId(userId).orElseThrow(() -> new FestimateException(ResponseError.USER_NOT_FOUND));
+        return findById(userId);
     }
 
     @Override
@@ -65,19 +65,18 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void updateRefreshToken(Long userId, String refreshToken) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new FestimateException(ResponseError.USER_NOT_FOUND));
+        User user = findById(userId);
         user.updateRefreshToken(refreshToken);
         userRepository.save(user);
     }
 
-    private void findByIdOrThrow(Long userId) {
+    @Override
+    public void findByIdOrThrow(Long userId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new FestimateException(ResponseError.USER_NOT_FOUND));
     }
 
-    private void findByPlatformId(String platformId) {
-        if (userRepository.findByPlatformId(platformId).isPresent()) {
-            throw new FestimateException(ResponseError.USER_ALREADY_EXISTS);
-        }
+    private User findById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new FestimateException(ResponseError.USER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] #22 페스티벌 생성 API 기능 구현

## 📌 PR 내용
- 어드민 페이지에서 페스티벌을 생성하는 API 기능을 구현합니다.

## 🛠 작업 내용
- [x] 페스티벌 생성 API

## 🔍 관련 이슈
Closes #22 

## 📸 스크린샷 (Optional)
<img width="456" alt="image" src="https://github.com/user-attachments/assets/e7d4f3e0-d90e-475b-b6f7-ec4602db412b" />

## 📚 레퍼런스 (Optional)
N/A