### PR TITLE
[feat] #24 페스티벌 생성 API 검증 로직 구현

### DIFF
--- a/src/main/java/org/festimate/team/common/response/ResponseError.java
+++ b/src/main/java/org/festimate/team/common/response/ResponseError.java
@@ -12,6 +12,7 @@ public enum ResponseError {
     INVALID_INPUT_LENGTH(4003, "입력된 글자수가 허용된 범위를 벗어났습니다."),
     INVALID_INPUT_NICKNAME(4004, "닉네임은 한글로만 입력 가능합니다."),
     INVALID_GRANT(4005, "유효하지 않은 인가 코드입니다."),
+    INVALID_DATE_TYPE(4006, "유효하지 않은 날짜 형식입니다."),
 
     // Unauthorized (401)
     INVALID_ACCESS_TOKEN(4011, "액세스 토큰의 값이 올바르지 않습니다."),

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -9,6 +9,9 @@ import org.festimate.team.user.entity.User;
 import org.festimate.team.user.service.UserService;
 import org.springframework.stereotype.Component;
 
+import static org.festimate.team.festival.validator.DateValidator.isFestivalDateValid;
+import static org.festimate.team.festival.validator.FestivalRequestValidator.isFestivalValid;
+
 @Component
 @RequiredArgsConstructor
 public class FestivalFacade {
@@ -17,6 +20,10 @@ public class FestivalFacade {
 
     public FestivalResponse createFestival(Long userId, FestivalRequest request) {
         User host = userService.getUserById(userId);
+
+        isFestivalValid(request.title(), request.category());
+        isFestivalDateValid(request.startDate(), request.endDate());
+
         Festival festival = festivalService.createFestival(host, request);
 
         return FestivalResponse.from(festival.getFestivalId(), festival.getInviteCode());

--- a/src/main/java/org/festimate/team/festival/dto/FestivalRequest.java
+++ b/src/main/java/org/festimate/team/festival/dto/FestivalRequest.java
@@ -1,12 +1,10 @@
 package org.festimate.team.festival.dto;
 
-import org.festimate.team.festival.entity.Category;
-
 import java.time.LocalDate;
 
 public record FestivalRequest(
         String title,
-        Category category,
+        String category,
         LocalDate startDate,
         LocalDate endDate
 ){}

--- a/src/main/java/org/festimate/team/festival/entity/Category.java
+++ b/src/main/java/org/festimate/team/festival/entity/Category.java
@@ -4,4 +4,8 @@ public enum Category {
     LIFE,
     MUSIC,
     SCHOOL;
+
+    public static Category toCategory(String category) {
+        return Category.valueOf(category.toUpperCase());
+    }
 }

--- a/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
+++ b/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
@@ -2,6 +2,7 @@ package org.festimate.team.festival.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.festimate.team.festival.dto.FestivalRequest;
+import org.festimate.team.festival.entity.Category;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.festival.repository.FestivalRepository;
 import org.festimate.team.festival.service.FestivalService;
@@ -26,7 +27,7 @@ public class FestivalServiceImpl implements FestivalService {
         Festival festival = Festival.builder()
                 .host(host)
                 .title(request.title())
-                .category(request.category())
+                .category(Category.toCategory(request.category()))
                 .startDate(request.startDate())
                 .endDate(request.endDate())
                 .inviteCode(inviteCode)

--- a/src/main/java/org/festimate/team/festival/validator/DateValidator.java
+++ b/src/main/java/org/festimate/team/festival/validator/DateValidator.java
@@ -1,0 +1,35 @@
+package org.festimate.team.festival.validator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.common.response.ResponseError;
+import org.festimate.team.exception.FestimateException;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@Slf4j
+public class DateValidator {
+
+    public static LocalDate parseAndValidateDate(final LocalDate date) {
+        if (date == null) {
+            throw new FestimateException(ResponseError.INVALID_DATE_TYPE);
+        }
+
+        return date;
+    }
+
+    public static void isFestivalDateValid(final LocalDate startDateStr, final LocalDate endDateStr) {
+        log.info("입력된 startDate: {}, endDate: {}", startDateStr, endDateStr);
+
+        LocalDate startDate = parseAndValidateDate(startDateStr);
+        LocalDate endDate = parseAndValidateDate(endDateStr);
+
+        if (startDate.isAfter(endDate)) {
+            throw new FestimateException(ResponseError.INVALID_DATE_TYPE);
+        }
+
+        log.info("날짜 검증 완료: startDate={}, endDate={}", startDate, endDate);
+    }
+}
+

--- a/src/main/java/org/festimate/team/festival/validator/FestivalRequestValidator.java
+++ b/src/main/java/org/festimate/team/festival/validator/FestivalRequestValidator.java
@@ -1,0 +1,38 @@
+package org.festimate.team.festival.validator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.common.response.ResponseError;
+import org.festimate.team.common.validator.LengthValidator;
+import org.festimate.team.exception.FestimateException;
+import org.festimate.team.festival.entity.Category;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class FestivalRequestValidator {
+    public static void isFestivalValid(final String title, final String category) {
+        isFestivalTitleValid(title);
+        isFestivalCategoryValid(category);
+    }
+
+    private static void isFestivalTitleValid(final String title) {
+        log.info("now value is : {}", title);
+        if (title.contains("\n")) {
+            log.error("그룹 제목에 엔터가 들어갔습니다.");
+            throw new FestimateException(ResponseError.BAD_REQUEST);
+        }
+        if (!LengthValidator.rangeLengthCheck(title, 1, 20)) {
+            log.error("그룹 제목 길이 검증에 실패하였습니다.");
+            throw new FestimateException(ResponseError.BAD_REQUEST);
+        }
+    }
+
+    private static void isFestivalCategoryValid(final String category) {
+        log.info("now value is : {}", category);
+        try {
+            Category.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new FestimateException(ResponseError.BAD_REQUEST);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] #24 페스티벌 생성 API 검증 로직 구현

## 📌 PR 내용
- 페스티벌 생성 API 검증 로직 구현

## 🛠 작업 내용
- [x] 페스티벌 제목 형식 및 내용 유효 여부 판단
- [x] 페스티벌 날짜 형식 유효 여부 판단
- [x] 페스티벌 카테고리 형식 및 내용 유효 여부 판단

## 🔍 관련 이슈
Closes #24 

## 📸 스크린샷 (Optional)

| 검증     | 제목, 카테고리                                                                 | 날짜                                                        |
|----------|----------------------------------------------------------------------|---------------------------------------------------------------------------|
| 이미지   | ![Image](https://github.com/user-attachments/assets/3e8df6e9-7792-4952-b341-563eade4b220) | ![Image](https://github.com/user-attachments/assets/3de4d047-e976-4aa0-9ed3-72cee7589a84) |

## 📚 레퍼런스 (Optional)
N/A