### PR TITLE
[feat] #26 초대코드 검증 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/festival/controller/FestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/FestivalController.java
@@ -7,6 +7,8 @@ import org.festimate.team.common.response.ResponseBuilder;
 import org.festimate.team.facade.FestivalFacade;
 import org.festimate.team.festival.dto.FestivalRequest;
 import org.festimate.team.festival.dto.FestivalResponse;
+import org.festimate.team.festival.dto.FestivalVerifyRequest;
+import org.festimate.team.festival.dto.FestivalVerifyResponse;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.festival.service.FestivalService;
 import org.springframework.http.ResponseEntity;
@@ -34,10 +36,15 @@ public class FestivalController {
         return ResponseBuilder.created(response);
     }
 
-    @GetMapping("/{inviteCode}")
-    public ResponseEntity<Festival> getFestivalByInviteCode(@PathVariable String inviteCode) {
-        Festival festival = festivalService.getFestivalByInviteCode(inviteCode);
-        return ResponseEntity.ok(festival);
+    @PostMapping("/verify")
+    public ResponseEntity<ApiResponse<FestivalVerifyResponse>> verifyFestival(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestBody FestivalVerifyRequest request
+    ) {
+        jwtProvider.parseTokenAndGetUserId(accessToken);
+        Festival festival = festivalService.getFestivalByInviteCode(request.inviteCode().trim());
+
+        return ResponseBuilder.ok(FestivalVerifyResponse.of(festival));
     }
 
     @GetMapping

--- a/src/main/java/org/festimate/team/festival/dto/FestivalVerifyRequest.java
+++ b/src/main/java/org/festimate/team/festival/dto/FestivalVerifyRequest.java
@@ -1,0 +1,3 @@
+package org.festimate.team.festival.dto;
+
+public record FestivalVerifyRequest(String inviteCode) {}

--- a/src/main/java/org/festimate/team/festival/dto/FestivalVerifyResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/FestivalVerifyResponse.java
@@ -1,0 +1,18 @@
+package org.festimate.team.festival.dto;
+
+import org.festimate.team.festival.entity.Category;
+import org.festimate.team.festival.entity.Festival;
+
+public record FestivalVerifyResponse(
+        Long festivalId,
+        String title,
+        Category category
+) {
+    public static FestivalVerifyResponse of(Festival festival) {
+        return new FestivalVerifyResponse(
+                festival.getFestivalId(),
+                festival.getTitle(),
+                festival.getCategory()
+        );
+    }
+}

--- a/src/main/java/org/festimate/team/festival/repository/FestivalRepository.java
+++ b/src/main/java/org/festimate/team/festival/repository/FestivalRepository.java
@@ -3,8 +3,10 @@ package org.festimate.team.festival.repository;
 import org.festimate.team.festival.entity.Festival;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FestivalRepository extends JpaRepository<Festival, Integer> {
     boolean existsByInviteCode(String inviteCode);
 
-    Festival findByInviteCode(String inviteCode);
+    Optional<Festival> findByInviteCode(String inviteCode);
 }

--- a/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
+++ b/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
@@ -13,6 +13,7 @@ import org.festimate.team.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Random;
 
@@ -44,8 +45,9 @@ public class FestivalServiceImpl implements FestivalService {
     @Transactional
     public Festival getFestivalByInviteCode(String inviteCode) {
         log.info("inviteCode: {}", inviteCode);
-        return festivalRepository.findByInviteCode(inviteCode)
+        Festival festival = festivalRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new FestimateException(ResponseError.FESTIVAL_NOT_FOUND));
+        return validateNotPastDate(festival);
     }
 
     @Override
@@ -60,5 +62,12 @@ public class FestivalServiceImpl implements FestivalService {
             inviteCode = String.valueOf(100000 + random.nextInt(900000));
         } while (festivalRepository.existsByInviteCode(inviteCode));
         return inviteCode;
+    }
+
+    private Festival validateNotPastDate(Festival festival) {
+        if (festival.getEndDate().isBefore(LocalDate.now())) {
+            throw new FestimateException(ResponseError.TARGET_NOT_FOUND);
+        }
+        return festival;
     }
 }

--- a/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
+++ b/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
@@ -1,6 +1,9 @@
 package org.festimate.team.festival.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.common.response.ResponseError;
+import org.festimate.team.exception.FestimateException;
 import org.festimate.team.festival.dto.FestivalRequest;
 import org.festimate.team.festival.entity.Category;
 import org.festimate.team.festival.entity.Festival;
@@ -15,6 +18,7 @@ import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class FestivalServiceImpl implements FestivalService {
 
     private final FestivalRepository festivalRepository;
@@ -22,7 +26,7 @@ public class FestivalServiceImpl implements FestivalService {
     @Override
     @Transactional
     public Festival createFestival(User host, FestivalRequest request) {
-        String inviteCode = generateUniqueInviteCode();
+        String inviteCode = generateUniqueInviteCode().trim();
 
         Festival festival = Festival.builder()
                 .host(host)
@@ -37,9 +41,11 @@ public class FestivalServiceImpl implements FestivalService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public Festival getFestivalByInviteCode(String inviteCode) {
-        return festivalRepository.findByInviteCode(inviteCode);
+        log.info("inviteCode: {}", inviteCode);
+        return festivalRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new FestimateException(ResponseError.FESTIVAL_NOT_FOUND));
     }
 
     @Override


### PR DESCRIPTION
## 📌 PR 제목
[feat] #26 초대코드 검증 API 기능 구현

## 📌 PR 내용
- 페스티벌 초대코드가 유효한지 검증하는 API의 기능을 구현했습니다.

## 🛠 작업 내용
- [x] 초대 코드 유효성 검사
- [x] 기간 만료되면 오류 발생

## 🔍 관련 이슈
Closes #26 

## 📸 스크린샷 (Optional)
| 화면     | 성공                                                                 | 존재하지 않는 페스티벌 초대코드              | 축제 기간이 지난 초대코드               |
|----------|----------------------------------------------------------------------|---------------------------------------------------------------------------|---------------------------------------------------------------------------|
| 이미지   | ![Image](https://github.com/user-attachments/assets/3d1fdd17-a1c3-4abc-9a72-3aabc644a4ee) | ![Image](https://github.com/user-attachments/assets/a53ca92c-5fb7-42be-9ca9-0b961d20228d) | ![image](https://github.com/user-attachments/assets/da1ba025-e80c-4e9f-8551-61a446ca0660) |




## 📚 레퍼런스 (Optional)
추가로 공유할 정보가 있다면 여기에 작성해주세요.
