### PR TITLE
[fix] #34 닉네임 조회 API response body 수정

### DIFF
--- a/src/main/java/org/festimate/team/user/controller/UserController.java
+++ b/src/main/java/org/festimate/team/user/controller/UserController.java
@@ -11,6 +11,7 @@ import org.festimate.team.global.jwt.JwtService;
 import org.festimate.team.global.jwt.TokenResponse;
 import org.festimate.team.user.dto.SignUpRequest;
 import org.festimate.team.user.dto.UserFestivalResponse;
+import org.festimate.team.user.dto.UserNicknameResponse;
 import org.festimate.team.user.entity.Platform;
 import org.festimate.team.user.service.UserService;
 import org.festimate.team.user.validator.NicknameValidator;
@@ -77,12 +78,12 @@ public class UserController {
     }
 
     @GetMapping("/nickname")
-    public ResponseEntity<ApiResponse<String>> getNickname(
+    public ResponseEntity<ApiResponse<UserNicknameResponse>> getNickname(
             @RequestHeader("Authorization") String accessToken
     ) {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
         String nickName = userService.getUserNickname(userId);
-        return ResponseBuilder.ok(nickName);
+        return ResponseBuilder.ok(UserNicknameResponse.from(nickName));
     }
 
     @GetMapping("/festival")

--- a/src/main/java/org/festimate/team/user/dto/UserNicknameResponse.java
+++ b/src/main/java/org/festimate/team/user/dto/UserNicknameResponse.java
@@ -1,0 +1,9 @@
+package org.festimate.team.user.dto;
+
+public record UserNicknameResponse(
+        String nickanme
+) {
+    public static UserNicknameResponse from(String nickanme) {
+        return new UserNicknameResponse(nickanme);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
[fix] #34 닉네임 조회 API response body 수정

## 📌 PR 내용
- 메인화면의 닉네임 조회 시 response 반환 타입을 string 에서 dto 로 변환하였습니다.

## 🛠 작업 내용
- 수정 전
```json
{
    "status": true,
    "code": 2000,
    "message": "요청이 성공했습니다.",
    "data": "개죽이"
}
```

- 수정 후
```json
{
    "status": true,
    "code": 2000,
    "message": "요청이 성공했습니다.",
    "data": {
        "nickanme": "개죽이"
    }
}
```

## 🔍 관련 이슈
Closes #34 

## 📸 스크린샷 (Optional)
<img width="628" alt="image" src="https://github.com/user-attachments/assets/d4a5a578-3ce2-47a6-9cad-805ba24f3c37" />

## 📚 레퍼런스 (Optional)
추가로 공유할 정보가 있다면 여기에 작성해주세요.
N/A