### PR TITLE
[fix] #36 페스티벌 입장 / 참가자 생성 API 분리

### DIFF
--- a/src/main/java/org/festimate/team/festival/controller/FestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/FestivalController.java
@@ -48,6 +48,18 @@ public class FestivalController {
     @PostMapping("/{festivalId}/entry")
     public ResponseEntity<ApiResponse<EntryResponse>> entryFestival(
             @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        EntryResponse response = festivalFacade.enterFestival(userId, festival);
+
+        return ResponseBuilder.ok(response);
+    }
+
+    @PostMapping("/{festivalId}/participant")
+    public ResponseEntity<ApiResponse<EntryResponse>> createParticipant(
+            @RequestHeader("Authorization") String accessToken,
             @PathVariable("festivalId") Long festivalId,
             @RequestBody ProfileRequest request
     ) {
@@ -55,7 +67,7 @@ public class FestivalController {
 
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
 
-        EntryResponse response = festivalFacade.enterFestival(userId, festival, request);
+        EntryResponse response = festivalFacade.createParticipant(userId, festival, request);
 
         return ResponseBuilder.created(response);
     }


### PR DESCRIPTION
## 📌 PR 제목
[fix] #36 페스티벌 입장 / 참가자 생성 API 분리

## 📌 PR 내용
- 하나의 API 에서 관리하던 페스티벌 입장 기능과 참가자 생성 기능을 각각의 API 로 분리

## 🛠 작업 내용
- [x] 이미 입장했던 페스티벌에 입장하는 API 기능 구현
- [x] 새로운 페스티벌 입장할 때 참가자 엔티티 생성

## 🔍 관련 이슈
Closes #36 

## 📸 스크린샷 (Optional)
| 항목 | 이미지 |
|------|--------|
| 참가자 생성 | ![참가자 생성](https://github.com/user-attachments/assets/6ffec606-e9e1-49b7-a6dc-6ef716394ccd) |
| 페스티벌 입장 | ![페스티벌 입장](https://github.com/user-attachments/assets/6e309d9d-b16b-492c-ad75-46aa00d0ed77) |

## 📚 레퍼런스 (Optional)
N/A