### PR TITLE
[feat] #38 참가자 유형 테스트 결과 조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/festival/dto/TypeRequest.java
+++ b/src/main/java/org/festimate/team/festival/dto/TypeRequest.java
@@ -1,0 +1,6 @@
+package org.festimate.team.festival.dto;
+
+public record TypeRequest(
+        Boolean q1, Boolean q2, Boolean q3, Boolean q4, Boolean q5
+) {
+}

--- a/src/main/java/org/festimate/team/festival/dto/TypeResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/TypeResponse.java
@@ -1,0 +1,9 @@
+package org.festimate.team.festival.dto;
+
+import org.festimate.team.participant.entity.TypeResult;
+
+public record TypeResponse(TypeResult typeResult) {
+    public static TypeResponse from(TypeResult typeResult) {
+        return new TypeResponse(typeResult);
+    }
+}

--- a/src/main/java/org/festimate/team/participant/controller/ParticipantController.java
+++ b/src/main/java/org/festimate/team/participant/controller/ParticipantController.java
@@ -1,0 +1,32 @@
+package org.festimate.team.participant.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.festimate.team.common.response.ApiResponse;
+import org.festimate.team.common.response.ResponseBuilder;
+import org.festimate.team.festival.dto.TypeRequest;
+import org.festimate.team.festival.dto.TypeResponse;
+import org.festimate.team.global.jwt.JwtService;
+import org.festimate.team.participant.service.ParticipantService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/v1/participant")
+@RequiredArgsConstructor
+public class ParticipantController {
+
+    private final JwtService jwtService;
+    private final ParticipantService participantService;
+
+    @PostMapping("/type")
+    public ResponseEntity<ApiResponse<TypeResponse>> getFestivalType(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestBody TypeRequest request
+    ) {
+        jwtService.parseTokenAndGetUserId(accessToken);
+
+        TypeResponse response = participantService.getTypeResult(request);
+        return ResponseBuilder.ok(response);
+    }
+}

--- a/src/main/java/org/festimate/team/participant/service/ParticipantService.java
+++ b/src/main/java/org/festimate/team/participant/service/ParticipantService.java
@@ -1,6 +1,8 @@
 package org.festimate.team.participant.service;
 
 
+import org.festimate.team.festival.dto.TypeRequest;
+import org.festimate.team.festival.dto.TypeResponse;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.participant.dto.ProfileRequest;
 import org.festimate.team.participant.entity.Participant;
@@ -17,4 +19,6 @@ public interface ParticipantService {
 
     @Transactional(readOnly = true)
     List<Festival> getFestivalsByUser(User user, String status);
+
+    TypeResponse getTypeResult(TypeRequest request);
 }

--- a/src/main/java/org/festimate/team/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/org/festimate/team/participant/service/impl/ParticipantServiceImpl.java
@@ -2,9 +2,12 @@ package org.festimate.team.participant.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.festival.dto.TypeRequest;
+import org.festimate.team.festival.dto.TypeResponse;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.participant.dto.ProfileRequest;
 import org.festimate.team.participant.entity.Participant;
+import org.festimate.team.participant.entity.TypeResult;
 import org.festimate.team.participant.repository.ParticipantRepository;
 import org.festimate.team.participant.service.ParticipantService;
 import org.festimate.team.user.entity.User;
@@ -46,5 +49,32 @@ public class ParticipantServiceImpl implements ParticipantService {
         return participantRepository.findAllByUser(user, status, LocalDate.now()).stream()
                 .map(Participant::getFestival)
                 .toList();
+    }
+
+    @Override
+    public TypeResponse getTypeResult(TypeRequest typeRequest) {
+        int[][] weights = new int[5][];
+        weights[0] = typeRequest.q1() ? new int[]{3, 1, 1, -1, -1} : new int[]{-3, -1, -1, 1, 1};
+        weights[1] = typeRequest.q2() ? new int[]{-2, 3, -1, 0, 0} : new int[]{2, -3, 1, 0, 0};
+        weights[2] = typeRequest.q3() ? new int[]{-1, -2, 3, 1, -2} : new int[]{1, 2, -3, -1, 2};
+        weights[3] = typeRequest.q4() ? new int[]{-1, -1, -2, 3, 1} : new int[]{1, 1, 2, -3, -1};
+        weights[4] = typeRequest.q5() ? new int[]{-1, 0, -1, 0, 3} : new int[]{1, 0, 1, 0, -3};
+
+        int[] totalScores = new int[5];
+
+        for (int[] weight : weights) {
+            for (int i = 0; i < 5; i++) {
+                totalScores[i] += weight[i];
+            }
+        }
+
+        int maxIdx = 0;
+        for (int i = 1; i < 5; i++) {
+            if (totalScores[i] > totalScores[maxIdx]) {
+                maxIdx = i;
+            }
+        }
+
+        return TypeResponse.from(TypeResult.values()[maxIdx]);
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] #38 참가자 유형 테스트 결과 조회 API 기능 구현

## 📌 PR 내용
- 참가자의 5가지 질문 응답을 바탕으로 유형을 도출하는 테스트 결과 조회 API를 구현했습니다.
- 각 질문은 다섯 개 유형에 대한 가중치(weight)를 가지며, 응답을 기반으로 총합을 계산하여 최종 유형을 판단합니다.

## 🛠 작업 내용
- [x]  TypeRequest(질문 5개 Boolean 응답) → TypeResponse(유형 String) 변환 로직 구현
- [x] 응답에 따라 가중치를 계산하는 알고리즘 설계
- [x] 가장 높은 점수를 받은 유형을 결과로 반환
- [x] API 명세에 따라 status, code, message, data 구조로 응답 반환
- [x] 관련 Enum(TypeResult) 및 응답 DTO 설계

총 5개의 질문(q1 ~ q5)에 대해 각 응답이 true/false일 때,
5가지 유형(INFLUENCER, NEWBIE, PHOTO, PLANNER, HEALING)에 서로 다른 가중치를 부여합니다.
유저의 대답에 따른 총합 점수를 기반으로 가장 높은 점수를 받은 유형을 최종 결과로 반환합니다.

가중치는 아래와 같이 구성되어 있으며, 질문 별 응답 결과에 따라 다르게 적용됩니다.
```java
weights[0] = q1 == true ? new int[]{3, 1, 1, -1, -1} : new int[]{-3, -1, -1, 1, 1};
```
## 최종 응답 예시
### 🔻 Request Body
```json
{
  "q1": false,
  "q2": true,
  "q3": false,
  "q4": false,
  "q5": true
}
```
### 🔺 Response Body (200 OK)
```json
{
  "status": true,
  "code": 2000,
  "message": "요청이 성공했습니다.",
  "data": {
    "typeResult": "HEALING"
  }
}
```

## 도출 가능한 유형 목록
`INFLUENCER`: 핵인싸메이트
`NEWBIE`: 뉴비메이트
`PHOTO`: 인증샷메이트
`PLANNER`: 계획파메이트
`HEALING`: 힐링메이트

## 🔍 관련 이슈
Closes #38 

## 📸 스크린샷 (Optional)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1e863489-a77b-4ac0-b4f2-0bb720461ffe" />

## 📚 레퍼런스 (Optional)
N/A