### PR TITLE
[feat] #40 페스티벌 상세 조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -40,15 +40,12 @@ public class FestivalFacade {
         return FestivalResponse.from(festival.getFestivalId(), festival.getInviteCode());
     }
 
+    @Transactional(readOnly = true)
     public EntryResponse enterFestival(Long userId, Festival festival) {
         User user = userService.getUserById(userId);
-        Participant participant = getParticipantInfo(user, festival);
+        Participant participant = getExistingParticipantOrThrow(user, festival);
 
-        if (participant == null) {
-            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
-        }
-
-        return EntryResponse.of(getParticipantInfo(user, festival));
+        return EntryResponse.of(participant);
     }
 
     @Transactional
@@ -66,6 +63,11 @@ public class FestivalFacade {
                 .toList();
     }
 
+    public void validateUserParticipation(Long userId, Festival festival) {
+        User user = userService.getUserById(userId);
+        getExistingParticipantOrThrow(user, festival);
+    }
+
     private Participant createParticipantIfValid(User user, Festival festival, ProfileRequest request) {
         if (getParticipantInfo(user, festival) != null) {
             throw new FestimateException(ResponseError.USER_ALREADY_EXISTS);
@@ -75,6 +77,14 @@ public class FestivalFacade {
             throw new FestimateException(ResponseError.EXPIRED_FESTIVAL);
         }
         return participantService.createParticipant(user, festival, request);
+    }
+
+    private Participant getExistingParticipantOrThrow(User user, Festival festival) {
+        Participant participant = participantService.getParticipant(user, festival);
+        if (participant == null) {
+            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
+        }
+        return participant;
     }
 
     private Participant getParticipantInfo(User user, Festival festival) {

--- a/src/main/java/org/festimate/team/festival/controller/FestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/FestivalController.java
@@ -77,4 +77,16 @@ public class FestivalController {
         List<Festival> festivals = festivalService.getAllFestivals();
         return ResponseEntity.ok(festivals);
     }
+
+    @GetMapping("/{festivalId}")
+    public ResponseEntity<ApiResponse<FestivalInfoResponse>> getFestivalInfo(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+
+        festivalFacade.validateUserParticipation(userId, festival);
+        return ResponseBuilder.ok(FestivalInfoResponse.of(festival));
+    }
 }

--- a/src/main/java/org/festimate/team/festival/dto/FestivalInfoResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/FestivalInfoResponse.java
@@ -1,0 +1,23 @@
+package org.festimate.team.festival.dto;
+
+import org.festimate.team.festival.entity.Festival;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public record FestivalInfoResponse(
+        String festivalName,
+        String festivalDate
+) {
+    public static FestivalInfoResponse of(Festival festival) {
+        return new FestivalInfoResponse(
+                festival.getTitle(),
+                formattingDate(festival.getStartDate(), festival.getEndDate())
+        );
+    }
+
+    private static String formattingDate(LocalDate startDate, LocalDate endDate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return startDate.format(formatter) + " ~ " + endDate.format(formatter);
+    }
+}

--- a/src/test/java/org/festimate/team/facade/FestivalFacadeTest.java
+++ b/src/test/java/org/festimate/team/facade/FestivalFacadeTest.java
@@ -1,0 +1,133 @@
+package org.festimate.team.facade;
+
+import org.festimate.team.common.response.ResponseError;
+import org.festimate.team.exception.FestimateException;
+import org.festimate.team.festival.dto.FestivalInfoResponse;
+import org.festimate.team.festival.entity.Category;
+import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.festival.service.FestivalService;
+import org.festimate.team.participant.entity.Participant;
+import org.festimate.team.participant.entity.TypeResult;
+import org.festimate.team.participant.service.ParticipantService;
+import org.festimate.team.user.entity.AppearanceType;
+import org.festimate.team.user.entity.Mbti;
+import org.festimate.team.user.entity.Platform;
+import org.festimate.team.user.entity.User;
+import org.festimate.team.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+class FestivalFacadeTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private FestivalService festivalService;
+
+    @Mock
+    private ParticipantService participantService;
+
+    @InjectMocks
+    private FestivalFacade festivalFacade;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("페스티벌 상세 조회 - 성공")
+    void getFestivalInfo_success() {
+        // given
+        Long userId = 1L;
+        Long festivalId = 100L;
+        User mockUser = User.builder()
+                .name("테스트 유저")
+                .phoneNumber("010-1234-5678")
+                .nickname("현진")
+                .birthYear(1999)
+                .mbti(Mbti.INFP)
+                .appearanceType(AppearanceType.BEAR)
+                .platformId("kakao_123456")
+                .platform(Platform.KAKAO)
+                .refreshToken("dummy_refresh_token")
+                .build();
+
+
+        Festival mockFestival = Festival.builder()
+                .host(mockUser)
+                .title("가톨릭대학교 다맛제")
+                .category(Category.LIFE)
+                .startDate(LocalDate.of(2025, 5, 18))
+                .endDate(LocalDate.of(2025, 5, 20))
+                .inviteCode("ABC123")
+                .build();
+
+        Participant mockParticipant = Participant.builder()
+                .user(mockUser)
+                .festival(mockFestival)
+                .typeResult(TypeResult.HEALING)
+                .introduction("안녕하세요~ 제 전화번호는요~")
+                .message("잘 부탁드려요 :)")
+                .build();
+
+        when(userService.getUserById(userId)).thenReturn(mockUser);
+        when(festivalService.getFestivalByIdOrThrow(festivalId)).thenReturn(mockFestival);
+        when(participantService.getParticipant(mockUser, mockFestival)).thenReturn(mockParticipant);
+
+        // when
+        festivalFacade.validateUserParticipation(userId, mockFestival);
+        FestivalInfoResponse response = FestivalInfoResponse.of(mockFestival);
+
+        // then
+        assertThat(response.festivalName()).isEqualTo("가톨릭대학교 다맛제");
+        assertThat(response.festivalDate()).isEqualTo("2025.05.18 ~ 2025.05.20");
+    }
+
+    @Test
+    @DisplayName("페스티벌 상세 조회 - 유저가 참가자가 아닌 경우 예외 발생")
+    void getFestivalInfo_fail_if_not_participant() {
+        // given
+        Long userId = 2L;
+
+        User mockUser = User.builder()
+                .name("테스트 유저")
+                .phoneNumber("010-1234-5678")
+                .nickname("현진")
+                .birthYear(1999)
+                .mbti(Mbti.INFP)
+                .appearanceType(AppearanceType.BEAR)
+                .platformId("kakao_123456")
+                .platform(Platform.KAKAO)
+                .refreshToken("dummy_refresh_token")
+                .build();
+
+        Festival mockFestival = Festival.builder()
+                .host(mockUser)
+                .title("가톨릭대학교 다맛제")
+                .category(Category.LIFE)
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(2))
+                .inviteCode("ABC123")
+                .build();
+
+        when(userService.getUserById(userId)).thenReturn(mockUser);
+        when(participantService.getParticipant(mockUser, mockFestival)).thenReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> festivalFacade.validateUserParticipation(userId, mockFestival))
+                .isInstanceOf(FestimateException.class)
+                .hasMessageContaining(ResponseError.FORBIDDEN_RESOURCE.getMessage());
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] #40 페스티벌 상세 조회 API 기능 구현

## 📌 PR 내용
- 페스티벌 입장 시 메인화면에서 페스티벌의 정보를 조회하는 API 를 구현했습니다.

## 🛠 작업 내용
- [ ] 유저 존재여부 확인
- [ ] 페스티벌 존재여부 확인
- [ ] 유저가 페스티벌 참가자인지 확인
- [ ] 페스티벌 이름 / 페스티벌 기간 반환

### 페스티벌 기간 반환 시
> 포맷팅을 통한 'yyyy-mm-dd ~ yyyy-mm-dd' 형태로 반환
```java
private static String formattingDate(LocalDate startDate, LocalDate endDate) {
        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
        return startDate.format(formatter) + " ~ " + endDate.format(formatter);
    }
```

## 🔍 관련 이슈
Closes #40 

## 📸 스크린샷 (Optional)
<img width="600" alt="image" src="https://github.com/user-attachments/assets/42ab9cd0-5a2c-4b4d-95e3-b77d486340d2" />

## 📚 레퍼런스 (Optional)
N/A