### PR TITLE
[feat] #42 유저 프로필 + 포인트 내역 조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -6,6 +6,7 @@ import org.festimate.team.exception.FestimateException;
 import org.festimate.team.festival.dto.EntryResponse;
 import org.festimate.team.festival.dto.FestivalRequest;
 import org.festimate.team.festival.dto.FestivalResponse;
+import org.festimate.team.festival.dto.MainUserInfoResponse;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.festival.service.FestivalService;
 import org.festimate.team.participant.dto.ProfileRequest;
@@ -61,6 +62,15 @@ public class FestivalFacade {
         return participantService.getFestivalsByUser(user, status).stream()
                 .map(UserFestivalResponse::from)
                 .toList();
+    }
+
+    public MainUserInfoResponse getParticipantAndPoint(Long userId, Festival festival) {
+        User user = userService.getUserById(userId);
+        Participant participant = getExistingParticipantOrThrow(user, festival);
+
+        int point = participantService.getTotalPointByParticipant(participant);
+
+        return MainUserInfoResponse.from(participant, point);
     }
 
     public void validateUserParticipation(Long userId, Festival festival) {

--- a/src/main/java/org/festimate/team/festival/controller/FestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/FestivalController.java
@@ -72,6 +72,19 @@ public class FestivalController {
         return ResponseBuilder.created(response);
     }
 
+    @GetMapping("/{festivalId}/participant/info")
+    public ResponseEntity<ApiResponse<MainUserInfoResponse>> getParticipantAndPoint(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+
+        MainUserInfoResponse response = festivalFacade.getParticipantAndPoint(userId, festival);
+
+        return ResponseBuilder.ok(response);
+    }
+
     @GetMapping
     public ResponseEntity<List<Festival>> getAllFestivals() {
         List<Festival> festivals = festivalService.getAllFestivals();

--- a/src/main/java/org/festimate/team/festival/dto/MainUserInfoResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/MainUserInfoResponse.java
@@ -1,0 +1,16 @@
+package org.festimate.team.festival.dto;
+
+import org.festimate.team.participant.entity.Participant;
+import org.festimate.team.participant.entity.TypeResult;
+
+public record MainUserInfoResponse(
+        TypeResult typeResult,
+        int point
+) {
+    public static MainUserInfoResponse from(Participant participant, int point) {
+        return new MainUserInfoResponse(
+                participant.getTypeResult(),
+                point
+        );
+    }
+}

--- a/src/main/java/org/festimate/team/participant/repository/ParticipantRepository.java
+++ b/src/main/java/org/festimate/team/participant/repository/ParticipantRepository.java
@@ -5,6 +5,7 @@ import org.festimate.team.participant.entity.Participant;
 import org.festimate.team.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,4 +18,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Intege
             ":status = 'END' AND p.festival.endDate < :today)")
     List<Participant> findAllByUser(User user, String status, LocalDate today);
 
+    @Query("SELECT COALESCE(SUM(p.point), 0) FROM Point p WHERE p.participant = :participant")
+    int getTotalPointByParticipant(@Param("participant") Participant participant);
 }

--- a/src/main/java/org/festimate/team/participant/service/ParticipantService.java
+++ b/src/main/java/org/festimate/team/participant/service/ParticipantService.java
@@ -21,4 +21,6 @@ public interface ParticipantService {
     List<Festival> getFestivalsByUser(User user, String status);
 
     TypeResponse getTypeResult(TypeRequest request);
+
+    int getTotalPointByParticipant(Participant participant);
 }

--- a/src/main/java/org/festimate/team/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/org/festimate/team/participant/service/impl/ParticipantServiceImpl.java
@@ -77,4 +77,10 @@ public class ParticipantServiceImpl implements ParticipantService {
 
         return TypeResponse.from(TypeResult.values()[maxIdx]);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public int getTotalPointByParticipant(Participant participant){
+        return participantRepository.getTotalPointByParticipant(participant);
+    }
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] #42 유저 프로필 + 포인트 내역 조회 API 기능 구현

## 📌 PR 내용
- 유저의 유형 테스트 결과를 조회하고, 잔여 포인트를 조회하는 API 기능을 구현했습니다.

## 🛠 작업 내용
- [ ] 유저의 유형 테스트 결과 조회
- [ ] 잔여 포인트 조회

### 고민한 사항
> 참가자의 포인트를 어디서 조회할 것인가?

1. 서비스에서 조회하는 방법 예시
```java
public int getCurrentPointByUserAndFestival(Long userId, Long festivalId) {
    Participant participant = participantRepository.findByUserIdAndFestivalId(userId, festivalId)
            .orElseThrow(() -> new FestimateException(ResponseError.PARTICIPANT_NOT_FOUND));

    return participant.calculateCurrentPoint();
}
```

2. PointRepository에서 쿼리로 합산
```java
@Query("SELECT COALESCE(SUM(p.point), 0) FROM Point p WHERE p.participant = :participant")
int getTotalPointByParticipant(@Param("participant") Participant participant);

```

결론 : 2번 선택!
> 쿼리 기반이라 N+1 이슈 없이 성능도 좋음
> 조건에 따라 충전만/차감만 합산하고 싶을 때도 유연하게 확장 가능

## 🔍 관련 이슈
Closes #42 

## 📸 스크린샷 (Optional)
<img width="627" alt="image" src="https://github.com/user-attachments/assets/f615464f-50ad-456d-a544-0fe6c0bdb8df" />

## 📚 레퍼런스 (Optional)
N/A