### PR TITLE
[feat] #44 마이페이지의 유저 프로필 조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -3,10 +3,7 @@ package org.festimate.team.facade;
 import lombok.RequiredArgsConstructor;
 import org.festimate.team.common.response.ResponseError;
 import org.festimate.team.exception.FestimateException;
-import org.festimate.team.festival.dto.EntryResponse;
-import org.festimate.team.festival.dto.FestivalRequest;
-import org.festimate.team.festival.dto.FestivalResponse;
-import org.festimate.team.festival.dto.MainUserInfoResponse;
+import org.festimate.team.festival.dto.*;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.festival.service.FestivalService;
 import org.festimate.team.participant.dto.ProfileRequest;
@@ -71,6 +68,12 @@ public class FestivalFacade {
         int point = participantService.getTotalPointByParticipant(participant);
 
         return MainUserInfoResponse.from(participant, point);
+    }
+
+    public ProfileResponse getParticipantProfile(Long userId, Festival festival) {
+        User user = userService.getUserById(userId);
+        Participant participant = getExistingParticipantOrThrow(user, festival);
+        return ProfileResponse.of(participant.getTypeResult(), user.getNickname());
     }
 
     public void validateUserParticipation(Long userId, Festival festival) {

--- a/src/main/java/org/festimate/team/festival/controller/FestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/FestivalController.java
@@ -72,7 +72,7 @@ public class FestivalController {
         return ResponseBuilder.created(response);
     }
 
-    @GetMapping("/{festivalId}/participant/info")
+    @GetMapping("/{festivalId}/my/info")
     public ResponseEntity<ApiResponse<MainUserInfoResponse>> getParticipantAndPoint(
             @RequestHeader("Authorization") String accessToken,
             @PathVariable("festivalId") Long festivalId
@@ -101,5 +101,17 @@ public class FestivalController {
 
         festivalFacade.validateUserParticipation(userId, festival);
         return ResponseBuilder.ok(FestivalInfoResponse.of(festival));
+    }
+
+    @GetMapping("/{festivalId}/my")
+    public ResponseEntity<ApiResponse<ProfileResponse>> getMyProfile(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+
+        ProfileResponse response = festivalFacade.getParticipantProfile(userId, festival);
+        return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/festival/dto/ProfileResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/ProfileResponse.java
@@ -1,0 +1,12 @@
+package org.festimate.team.festival.dto;
+
+import org.festimate.team.participant.entity.TypeResult;
+
+public record ProfileResponse(
+        TypeResult typeResult,
+        String nickname
+) {
+    public static ProfileResponse of(TypeResult typeResult, String nickname) {
+        return new ProfileResponse(typeResult, nickname);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] #44 마이페이지의 유저 프로필 조회 API 기능 구현

## 📌 PR 내용
- 마이페이지의 유저 프로필 조회 API 기능을 구현했습니다.

## 🛠 작업 내용
- [ ] 참가자의 유형 조회
- [ ] 유저의 닉네임 조회

### 참가자일 경우 (성공)
```json
{
    "status": true,
    "code": 2000,
    "message": "요청이 성공했습니다.",
    "data": {
        "typeResult": "HEALING",
        "nickname": "개죽이"
    }
}
```

### 참가자가 아닐 경우 
```json
{
    "status": false,
    "code": 4030,
    "message": "리소스 접근 권한이 없습니다.",
    "data": null
}
```

## 🔍 관련 이슈
Closes #44

## 📸 스크린샷 (Optional)
<img width="625" alt="image" src="https://github.com/user-attachments/assets/7f4c0ea2-092f-42ee-bcef-b9bc945d902c" />

## 📚 레퍼런스 (Optional)
추가로 공유할 정보가 있다면 여기에 작성해주세요.
N/A