### PR TITLE
[feat] #46 내 프로필 상세 조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -76,6 +76,12 @@ public class FestivalFacade {
         return ProfileResponse.of(participant.getTypeResult(), user.getNickname());
     }
 
+    public DetailProfileResponse getParticipantType(Long userId, Festival festival) {
+        User user = userService.getUserById(userId);
+        Participant participant = getExistingParticipantOrThrow(user, festival);
+        return DetailProfileResponse.from(user, participant);
+    }
+
     public void validateUserParticipation(Long userId, Festival festival) {
         User user = userService.getUserById(userId);
         getExistingParticipantOrThrow(user, festival);

--- a/src/main/java/org/festimate/team/festival/controller/FestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/FestivalController.java
@@ -114,4 +114,17 @@ public class FestivalController {
         ProfileResponse response = festivalFacade.getParticipantProfile(userId, festival);
         return ResponseBuilder.ok(response);
     }
+
+    @GetMapping("/{festivalId}/my/type")
+    public ResponseEntity<ApiResponse<DetailProfileResponse>> getParticipantType(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+
+        DetailProfileResponse response = festivalFacade.getParticipantType(userId, festival);
+
+        return ResponseBuilder.ok(response);
+    }
 }

--- a/src/main/java/org/festimate/team/festival/dto/DetailProfileResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/DetailProfileResponse.java
@@ -1,0 +1,32 @@
+package org.festimate.team.festival.dto;
+
+import org.festimate.team.participant.entity.Participant;
+import org.festimate.team.participant.entity.TypeResult;
+import org.festimate.team.user.entity.AppearanceType;
+import org.festimate.team.user.entity.Gender;
+import org.festimate.team.user.entity.Mbti;
+import org.festimate.team.user.entity.User;
+
+public record DetailProfileResponse(
+        String nickname,
+        Gender gender,
+        int birthYear,
+        Mbti mbti,
+        AppearanceType appearanceType,
+        String introduction,
+        String message,
+        TypeResult typeResult
+) {
+    public static DetailProfileResponse from(User user, Participant participant) {
+        return new DetailProfileResponse(
+                user.getNickname(),
+                user.getGender(),
+                user.getBirthYear(),
+                user.getMbti(),
+                user.getAppearanceType(),
+                participant.getIntroduction(),
+                participant.getMessage(),
+                participant.getTypeResult()
+        );
+    }
+}

--- a/src/main/java/org/festimate/team/user/entity/User.java
+++ b/src/main/java/org/festimate/team/user/entity/User.java
@@ -33,6 +33,9 @@ public class User extends BaseTimeEntity {
     private int birthYear;
 
     @Column(nullable = false)
+    private Gender gender;
+
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Mbti mbti;
 
@@ -50,12 +53,13 @@ public class User extends BaseTimeEntity {
     private String refreshToken;
 
     @Builder
-    public User(String name, String phoneNumber, String nickname, Integer birthYear, Mbti mbti,
+    public User(String name, String phoneNumber, String nickname, Integer birthYear, Gender gender, Mbti mbti,
                 AppearanceType appearanceType, String platformId, Platform platform, String refreshToken) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.nickname = nickname;
         this.birthYear = birthYear;
+        this.gender = gender;
         this.mbti = mbti;
         this.appearanceType = appearanceType;
         this.platformId = platformId;

--- a/src/main/java/org/festimate/team/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/festimate/team/user/service/impl/UserServiceImpl.java
@@ -38,6 +38,7 @@ public class UserServiceImpl implements UserService {
                 .phoneNumber(request.phoneNumber())
                 .nickname(request.nickName())
                 .birthYear(request.birthYear())
+                .gender(request.gender())
                 .mbti(request.mbti())
                 .appearanceType(request.appearanceType())
                 .platformId(platformId)


### PR DESCRIPTION
## 📌 PR 제목
[feat] #46 내 프로필 상세 조회 API 기능 구현

## 📌 PR 내용
- 마이페이지의 유저 프로필 상세 조회 API 기능을 구현했습니다.

## 🛠 작업 내용
- [ ] 유저의 닉네임 조회
- [ ] 유저의 성별 조회
- [ ] 유저의 태어난 연도 조회
- [ ] 유저의 mbti 조회
- [ ] 유저의 AppearanceType 조회
- [ ] 참가자의 연락 정보 조회
- [ ] 참가자의 전달할 메세지 조회
- [ ] 참가자 유형 테스트 결과 조회

## 🔍 관련 이슈
Closes #46 

## 📸 스크린샷 (Optional)
<img width="640" alt="image" src="https://github.com/user-attachments/assets/a24e864c-db45-42a5-96fe-30b3a6665437" />

## 📚 레퍼런스 (Optional)
N/A