### PR TITLE
[feat] #48 내 연락처정보 및 메시지 수정 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -85,6 +85,9 @@ public class FestivalFacade {
     @Transactional
     public void modifyMyMessage(Long userId, Festival festival, MessageRequest messageRequest) {
         Participant participant = getExistingParticipantOrThrow(userId, festival);
+        if (messageRequest.introduction() == null) {
+            throw new FestimateException(ResponseError.BAD_REQUEST);
+        }
         participant.modifyIntroductionAndMessage(messageRequest.introduction(), messageRequest.message());
     }
 

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -40,8 +40,7 @@ public class FestivalFacade {
 
     @Transactional(readOnly = true)
     public EntryResponse enterFestival(Long userId, Festival festival) {
-        User user = userService.getUserById(userId);
-        Participant participant = getExistingParticipantOrThrow(user, festival);
+        Participant participant = getExistingParticipantOrThrow(userId, festival);
 
         return EntryResponse.of(participant);
     }
@@ -62,8 +61,7 @@ public class FestivalFacade {
     }
 
     public MainUserInfoResponse getParticipantAndPoint(Long userId, Festival festival) {
-        User user = userService.getUserById(userId);
-        Participant participant = getExistingParticipantOrThrow(user, festival);
+        Participant participant = getExistingParticipantOrThrow(userId, festival);
 
         int point = participantService.getTotalPointByParticipant(participant);
 
@@ -71,20 +69,23 @@ public class FestivalFacade {
     }
 
     public ProfileResponse getParticipantProfile(Long userId, Festival festival) {
-        User user = userService.getUserById(userId);
-        Participant participant = getExistingParticipantOrThrow(user, festival);
-        return ProfileResponse.of(participant.getTypeResult(), user.getNickname());
+        Participant participant = getExistingParticipantOrThrow(userId, festival);
+        return ProfileResponse.of(participant.getTypeResult(), participant.getUser().getNickname());
     }
 
     public DetailProfileResponse getParticipantType(Long userId, Festival festival) {
-        User user = userService.getUserById(userId);
-        Participant participant = getExistingParticipantOrThrow(user, festival);
-        return DetailProfileResponse.from(user, participant);
+        Participant participant = getExistingParticipantOrThrow(userId, festival);
+        return DetailProfileResponse.from(participant.getUser(), participant);
     }
 
     public void validateUserParticipation(Long userId, Festival festival) {
-        User user = userService.getUserById(userId);
-        getExistingParticipantOrThrow(user, festival);
+        getExistingParticipantOrThrow(userId, festival);
+    }
+
+    @Transactional
+    public void modifyMyMessage(Long userId, Festival festival, MessageRequest messageRequest) {
+        Participant participant = getExistingParticipantOrThrow(userId, festival);
+        participant.modifyIntroductionAndMessage(messageRequest.introduction(), messageRequest.message());
     }
 
     private Participant createParticipantIfValid(User user, Festival festival, ProfileRequest request) {
@@ -98,7 +99,8 @@ public class FestivalFacade {
         return participantService.createParticipant(user, festival, request);
     }
 
-    private Participant getExistingParticipantOrThrow(User user, Festival festival) {
+    private Participant getExistingParticipantOrThrow(Long userId, Festival festival) {
+        User user = userService.getUserById(userId);
         Participant participant = participantService.getParticipant(user, festival);
         if (participant == null) {
             throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);

--- a/src/main/java/org/festimate/team/festival/controller/FestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/FestivalController.java
@@ -108,4 +108,19 @@ public class FestivalController {
 
         return ResponseBuilder.ok(response);
     }
+
+    @PatchMapping("/{festivalId}/me/message")
+    public ResponseEntity<ApiResponse<Void>> modifyMyMessage(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @RequestBody MessageRequest request
+    ){
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+
+        festivalFacade.modifyMyMessage(userId, festival, request);
+
+        return ResponseBuilder.created(null);
+    }
+
 }

--- a/src/main/java/org/festimate/team/festival/dto/MessageRequest.java
+++ b/src/main/java/org/festimate/team/festival/dto/MessageRequest.java
@@ -1,0 +1,10 @@
+package org.festimate.team.festival.dto;
+
+public record MessageRequest(
+        String introduction,
+        String message
+) {
+    public static MessageRequest of(String introduction, String message) {
+        return new MessageRequest(introduction, message);
+    }
+}

--- a/src/main/java/org/festimate/team/participant/entity/Participant.java
+++ b/src/main/java/org/festimate/team/participant/entity/Participant.java
@@ -59,4 +59,9 @@ public class Participant extends BaseTimeEntity {
         this.introduction = introduction;
         this.message = message;
     }
+
+    public void modifyIntroductionAndMessage(String introduction, String message) {
+        this.introduction = introduction;
+        this.message = message;
+    }
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] #48 내 연락처정보 및 메시지 수정 API 기능 구현

## 📌 PR 내용
- 마이페이지에서 연락처정보 및 메세지를 수정할 수 있는 API 기능을 구현했습니다.

## 🛠 작업 내용
- [x] 연락처 정보 및 메세지 수정 기능 구현
```json
{
	"introduction" : "메세지 수정했지롱 ~",
	"message" : "롱롱소세지"
}
```
- [x] 연락처 정보 생략 시 에러 발생
- [x] 메세지 정보 생략 가능

## 🔍 관련 이슈
Closed #48 

## 📸 스크린샷 (Optional)
<img width="600" alt="image" src="https://github.com/user-attachments/assets/732c8c4d-4d1e-4e0f-96d4-33018cf77c23" />
<img width="367" alt="image" src="https://github.com/user-attachments/assets/5d84b1ab-794b-4e41-bc2a-82930f6e7bc9" />

## 📚 레퍼런스 (Optional)
N/A