### PR TITLE
[feat] #52 내 포인트 내역 조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/Point/dto/PointHistory.java
+++ b/src/main/java/org/festimate/team/Point/dto/PointHistory.java
@@ -1,0 +1,25 @@
+package org.festimate.team.Point.dto;
+
+import org.festimate.team.Point.entity.Point;
+import org.festimate.team.Point.entity.TransactionType;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public record PointHistory(
+        TransactionType transactionType,
+        int point,
+        String date
+) {
+    public static PointHistory from(Point point) {
+        String formattedDate = point.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm"));
+        return new PointHistory(point.getTransactionType(), point.getPoint(), formattedDate);
+    }
+
+    public static List<PointHistory> from(List<Point> points) {
+        return points.stream()
+                .sorted((p1, p2) -> p2.getCreatedAt().compareTo(p1.getCreatedAt()))
+                .map(PointHistory::from)
+                .toList();
+    }
+}

--- a/src/main/java/org/festimate/team/Point/dto/PointHistoryResponse.java
+++ b/src/main/java/org/festimate/team/Point/dto/PointHistoryResponse.java
@@ -1,0 +1,13 @@
+package org.festimate.team.Point.dto;
+
+import java.util.List;
+
+public record PointHistoryResponse(
+        int totalPoint,
+        List<PointHistory> histories
+) {
+    public static PointHistoryResponse from(int totalPoint, List<PointHistory> histories) {
+        return new PointHistoryResponse(totalPoint, histories);
+    }
+
+}

--- a/src/main/java/org/festimate/team/Point/repository/PointRepository.java
+++ b/src/main/java/org/festimate/team/Point/repository/PointRepository.java
@@ -1,0 +1,23 @@
+package org.festimate.team.Point.repository;
+
+import org.festimate.team.Point.entity.Point;
+import org.festimate.team.participant.entity.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+
+public interface PointRepository extends JpaRepository<Point, Integer> {
+    @Query(value = """
+                SELECT COALESCE(SUM(
+                    CASE 
+                        WHEN p.transaction_type = 'CREDIT' THEN p.point
+                        WHEN p.transaction_type = 'DEBIT' THEN -1 * p.point
+                        ELSE 0
+                    END
+                ), 0)
+                FROM point p
+                WHERE p.participant_id = :participantId
+            """, nativeQuery = true)
+    int getTotalPointByParticipant(@Param("participantId") Long participantId);
+}

--- a/src/main/java/org/festimate/team/Point/repository/PointRepository.java
+++ b/src/main/java/org/festimate/team/Point/repository/PointRepository.java
@@ -1,7 +1,6 @@
 package org.festimate.team.Point.repository;
 
 import org.festimate.team.Point.entity.Point;
-import org.festimate.team.participant.entity.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/org/festimate/team/Point/service/PointService.java
+++ b/src/main/java/org/festimate/team/Point/service/PointService.java
@@ -1,0 +1,10 @@
+package org.festimate.team.Point.service;
+
+import org.festimate.team.Point.dto.PointHistoryResponse;
+import org.festimate.team.participant.entity.Participant;
+
+public interface PointService {
+    PointHistoryResponse getPointHistory(Participant participant);
+
+    int getTotalPointByParticipant(Participant participant);
+}

--- a/src/main/java/org/festimate/team/Point/service/impl/PointServiceImpl.java
+++ b/src/main/java/org/festimate/team/Point/service/impl/PointServiceImpl.java
@@ -1,0 +1,33 @@
+package org.festimate.team.Point.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.Point.dto.PointHistory;
+import org.festimate.team.Point.dto.PointHistoryResponse;
+import org.festimate.team.Point.repository.PointRepository;
+import org.festimate.team.Point.service.PointService;
+import org.festimate.team.participant.entity.Participant;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PointServiceImpl implements PointService {
+
+    private final PointRepository pointRepository;
+
+    @Override
+    public PointHistoryResponse getPointHistory(Participant participant) {
+        List<PointHistory> histories = PointHistory.from(participant.getPoints());
+        int totalPoint = getTotalPointByParticipant(participant);
+        return PointHistoryResponse.from(totalPoint, histories);
+    }
+
+    @Override
+    public int getTotalPointByParticipant(Participant participant) {
+        return pointRepository.getTotalPointByParticipant(participant.getParticipantId());
+    }
+
+}

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -1,6 +1,8 @@
 package org.festimate.team.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.festimate.team.Point.dto.PointHistoryResponse;
+import org.festimate.team.Point.service.PointService;
 import org.festimate.team.common.response.ResponseError;
 import org.festimate.team.exception.FestimateException;
 import org.festimate.team.festival.dto.*;
@@ -26,6 +28,7 @@ public class FestivalFacade {
     private final UserService userService;
     private final FestivalService festivalService;
     private final ParticipantService participantService;
+    private final PointService pointService;
 
     public FestivalResponse createFestival(Long userId, FestivalRequest request) {
         User host = userService.getUserById(userId);
@@ -63,7 +66,7 @@ public class FestivalFacade {
     public MainUserInfoResponse getParticipantAndPoint(Long userId, Festival festival) {
         Participant participant = getExistingParticipantOrThrow(userId, festival);
 
-        int point = participantService.getTotalPointByParticipant(participant);
+        int point = pointService.getTotalPointByParticipant(participant);
 
         return MainUserInfoResponse.from(participant, point);
     }
@@ -89,6 +92,13 @@ public class FestivalFacade {
             throw new FestimateException(ResponseError.BAD_REQUEST);
         }
         participant.modifyIntroductionAndMessage(messageRequest.introduction(), messageRequest.message());
+    }
+
+    @Transactional(readOnly = true)
+    public PointHistoryResponse getMyPointHistory(Long userId, Festival festival) {
+        Participant participant = getExistingParticipantOrThrow(userId, festival);
+
+        return pointService.getPointHistory(participant);
     }
 
     private Participant createParticipantIfValid(User user, Festival festival, ProfileRequest request) {

--- a/src/main/java/org/festimate/team/festival/controller/FestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/FestivalController.java
@@ -1,6 +1,7 @@
 package org.festimate.team.festival.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.festimate.team.Point.dto.PointHistoryResponse;
 import org.festimate.team.common.response.ApiResponse;
 import org.festimate.team.common.response.ResponseBuilder;
 import org.festimate.team.facade.FestivalFacade;
@@ -123,4 +124,16 @@ public class FestivalController {
         return ResponseBuilder.created(null);
     }
 
+    @GetMapping("/{festivalId}/me/points")
+    public ResponseEntity<ApiResponse<PointHistoryResponse>> getMyPointHistory(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+
+        PointHistoryResponse response = festivalFacade.getMyPointHistory(userId, festival);
+
+        return ResponseBuilder.ok(response);
+    }
 }

--- a/src/main/java/org/festimate/team/participant/service/ParticipantService.java
+++ b/src/main/java/org/festimate/team/participant/service/ParticipantService.java
@@ -21,6 +21,4 @@ public interface ParticipantService {
     List<Festival> getFestivalsByUser(User user, String status);
 
     TypeResponse getTypeResult(TypeRequest request);
-
-    int getTotalPointByParticipant(Participant participant);
 }

--- a/src/main/java/org/festimate/team/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/org/festimate/team/participant/service/impl/ParticipantServiceImpl.java
@@ -77,10 +77,4 @@ public class ParticipantServiceImpl implements ParticipantService {
 
         return TypeResponse.from(TypeResult.values()[maxIdx]);
     }
-
-    @Override
-    @Transactional(readOnly = true)
-    public int getTotalPointByParticipant(Participant participant){
-        return participantRepository.getTotalPointByParticipant(participant);
-    }
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] #52 내 포인트 내역 조회 API 기능 구현

## 📌 PR 내용
- 마이페이지에서 내가 사용 및 충전한 포인트 내역을 조회할 수 있는 기능을 구현했습니다.

## 🛠 작업 내용
- [x] 잔여 포인트 조회
- [x] 충전 / 사용 여부
- [x] 충전 및 사용 시간
- [x] 충전 및 사용 포인트
- [x] 최신순 정렬
- [x] 충전 -> 덧셈 / 사용 -> 뺄셈 으로 잔여포인트 계산 로직 구현

```
participant 서비스에서 잔여 포인트를 계산하는 로직을 구현하려고 했는데 해당 방식은 모든 포인트를 메모리로 가져오기 때문에,
포인트 수가 많아질 경우엔 성능 이슈가 생길 거라고 생각했습니다.
→ 이에 PointRepository에서 @Query로 CREDIT/DEBIT 구분하여 SUM() 처리하는 방식으로 구현했습니다.
```
```java
public interface PointRepository extends JpaRepository<Point, Integer> {
    @Query(value = """
                SELECT COALESCE(SUM(
                    CASE 
                        WHEN p.transaction_type = 'CREDIT' THEN p.point
                        WHEN p.transaction_type = 'DEBIT' THEN -1 * p.point
                        ELSE 0
                    END
                ), 0)
                FROM point p
                WHERE p.participant_id = :participantId
            """, nativeQuery = true)
    int getTotalPointByParticipant(@Param("participantId") Long participantId);
}
```

## 🔍 관련 이슈
Closes #52 

## 📸 스크린샷 (Optional)
<img width="681" alt="image" src="https://github.com/user-attachments/assets/609ac59f-db7a-4765-b403-ab29eb75b171" />

## 📚 레퍼런스 (Optional)
N/A