### PR TITLE
[feat] 매칭 추가하기 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/Point/service/PointService.java
+++ b/src/main/java/org/festimate/team/Point/service/PointService.java
@@ -2,9 +2,13 @@ package org.festimate.team.Point.service;
 
 import org.festimate.team.Point.dto.PointHistoryResponse;
 import org.festimate.team.participant.entity.Participant;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface PointService {
     PointHistoryResponse getPointHistory(Participant participant);
 
     int getTotalPointByParticipant(Participant participant);
+
+    @Transactional
+    void usePoint(Participant participant);
 }

--- a/src/main/java/org/festimate/team/Point/service/impl/PointServiceImpl.java
+++ b/src/main/java/org/festimate/team/Point/service/impl/PointServiceImpl.java
@@ -4,10 +4,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.festimate.team.Point.dto.PointHistory;
 import org.festimate.team.Point.dto.PointHistoryResponse;
+import org.festimate.team.Point.entity.Point;
+import org.festimate.team.Point.entity.TransactionType;
 import org.festimate.team.Point.repository.PointRepository;
 import org.festimate.team.Point.service.PointService;
+import org.festimate.team.common.response.ResponseError;
+import org.festimate.team.exception.FestimateException;
 import org.festimate.team.participant.entity.Participant;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -28,6 +33,23 @@ public class PointServiceImpl implements PointService {
     @Override
     public int getTotalPointByParticipant(Participant participant) {
         return pointRepository.getTotalPointByParticipant(participant.getParticipantId());
+    }
+
+    @Transactional
+    @Override
+    public void usePoint(Participant participant) {
+        int totalPoint = getTotalPointByParticipant(participant);
+        if (totalPoint < 1) {
+            throw new FestimateException(ResponseError.INSUFFICIENT_POINTS);
+        }
+
+        Point pointUsage = Point.builder()
+                .participant(participant)
+                .point(1)
+                .transactionType(TransactionType.DEBIT)
+                .build();
+
+        pointRepository.save(pointUsage);
     }
 
 }

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -8,6 +8,9 @@ import org.festimate.team.exception.FestimateException;
 import org.festimate.team.festival.dto.*;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.festival.service.FestivalService;
+import org.festimate.team.matching.dto.MatchingStatusResponse;
+import org.festimate.team.matching.entity.Matching;
+import org.festimate.team.matching.service.MatchingService;
 import org.festimate.team.participant.dto.ProfileRequest;
 import org.festimate.team.participant.entity.Participant;
 import org.festimate.team.participant.service.ParticipantService;
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.festimate.team.festival.validator.DateValidator.isFestivalDateValid;
 import static org.festimate.team.festival.validator.FestivalRequestValidator.isFestivalValid;
@@ -29,6 +33,7 @@ public class FestivalFacade {
     private final FestivalService festivalService;
     private final ParticipantService participantService;
     private final PointService pointService;
+    private final MatchingService matchingService;
 
     public FestivalResponse createFestival(Long userId, FestivalRequest request) {
         User host = userService.getUserById(userId);
@@ -52,7 +57,10 @@ public class FestivalFacade {
     public EntryResponse createParticipant(Long userId, Festival festival, ProfileRequest request) {
         User user = userService.getUserById(userId);
 
-        return EntryResponse.of(createParticipantIfValid(user, festival, request));
+        Participant participant = createParticipantIfValid(user, festival, request);
+
+        matchingService.matchPendingParticipants(participant);
+        return EntryResponse.of(participant);
     }
 
     @Transactional(readOnly = true)
@@ -99,6 +107,19 @@ public class FestivalFacade {
         Participant participant = getExistingParticipantOrThrow(userId, festival);
 
         return pointService.getPointHistory(participant);
+    }
+
+    @Transactional
+    public MatchingStatusResponse createMatching(Long userId, long festivalId) {
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        Participant participant = getExistingParticipantOrThrow(userId, festival);
+
+        pointService.usePoint(participant);
+
+        Optional<Participant> targetParticipantOptional = matchingService.findMatchingCandidate(festivalId, participant);
+
+        Matching matching = matchingService.createMatching(festival, targetParticipantOptional, participant);
+        return MatchingStatusResponse.of(matching.getStatus(), matching.getMatchingId(), matching.getMatchDate());
     }
 
     private Participant createParticipantIfValid(User user, Festival festival, ProfileRequest request) {

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -119,7 +119,7 @@ public class FestivalFacade {
         Optional<Participant> targetParticipantOptional = matchingService.findBestCandidateByPriority(festivalId, participant);
 
         Matching matching = matchingService.createMatching(festival, targetParticipantOptional, participant);
-        return MatchingStatusResponse.of(matching.getStatus(), matching.getMatchingId(), matching.getMatchDate());
+        return MatchingStatusResponse.of(matching.getStatus(), matching.getMatchingId());
     }
 
     private Participant createParticipantIfValid(User user, Festival festival, ProfileRequest request) {

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -116,7 +116,7 @@ public class FestivalFacade {
 
         pointService.usePoint(participant);
 
-        Optional<Participant> targetParticipantOptional = matchingService.findMatchingCandidate(festivalId, participant);
+        Optional<Participant> targetParticipantOptional = matchingService.findBestCandidateByPriority(festivalId, participant);
 
         Matching matching = matchingService.createMatching(festival, targetParticipantOptional, participant);
         return MatchingStatusResponse.of(matching.getStatus(), matching.getMatchingId(), matching.getMatchDate());

--- a/src/main/java/org/festimate/team/matching/controller/MatchingController.java
+++ b/src/main/java/org/festimate/team/matching/controller/MatchingController.java
@@ -1,0 +1,31 @@
+package org.festimate.team.matching.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.festimate.team.common.response.ApiResponse;
+import org.festimate.team.common.response.ResponseBuilder;
+import org.festimate.team.facade.FestivalFacade;
+import org.festimate.team.global.jwt.JwtService;
+import org.festimate.team.matching.dto.MatchingStatusResponse;
+import org.festimate.team.matching.service.MatchingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/festivals")
+@RequiredArgsConstructor
+public class MatchingController {
+    private final MatchingService matchingService;
+    private final FestivalFacade festivalFacade;
+    private final JwtService jwtService;
+
+    @PostMapping("/{festivalId}/matchings")
+    public ResponseEntity<ApiResponse<MatchingStatusResponse>> createMatching(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+
+        MatchingStatusResponse response = festivalFacade.createMatching(userId, festivalId);
+        return ResponseBuilder.created(response);
+    }
+}

--- a/src/main/java/org/festimate/team/matching/dto/MatchingStatusResponse.java
+++ b/src/main/java/org/festimate/team/matching/dto/MatchingStatusResponse.java
@@ -2,11 +2,14 @@ package org.festimate.team.matching.dto;
 
 import org.festimate.team.matching.entity.MatchingStatus;
 
+import java.time.LocalDateTime;
+
 public record MatchingStatusResponse(
         MatchingStatus status,
-        long matchingId
+        Long matchingId,
+        LocalDateTime matchDate
 ) {
-    public static MatchingStatusResponse of(MatchingStatus status, long matchingId) {
-        return new MatchingStatusResponse(status, matchingId);
+    public static MatchingStatusResponse of(MatchingStatus status, Long matchingId, LocalDateTime matchDate) {
+        return new MatchingStatusResponse(status, matchingId, matchDate);
     }
 }

--- a/src/main/java/org/festimate/team/matching/dto/MatchingStatusResponse.java
+++ b/src/main/java/org/festimate/team/matching/dto/MatchingStatusResponse.java
@@ -2,14 +2,11 @@ package org.festimate.team.matching.dto;
 
 import org.festimate.team.matching.entity.MatchingStatus;
 
-import java.time.LocalDateTime;
-
 public record MatchingStatusResponse(
         MatchingStatus status,
-        Long matchingId,
-        LocalDateTime matchDate
+        Long matchingId
 ) {
-    public static MatchingStatusResponse of(MatchingStatus status, Long matchingId, LocalDateTime matchDate) {
-        return new MatchingStatusResponse(status, matchingId, matchDate);
+    public static MatchingStatusResponse of(MatchingStatus status, Long matchingId) {
+        return new MatchingStatusResponse(status, matchingId);
     }
 }

--- a/src/main/java/org/festimate/team/matching/dto/MatchingStatusResponse.java
+++ b/src/main/java/org/festimate/team/matching/dto/MatchingStatusResponse.java
@@ -6,4 +6,7 @@ public record MatchingStatusResponse(
         MatchingStatus status,
         long matchingId
 ) {
+    public static MatchingStatusResponse of(MatchingStatus status, long matchingId) {
+        return new MatchingStatusResponse(status, matchingId);
+    }
 }

--- a/src/main/java/org/festimate/team/matching/dto/MatchingStatusResponse.java
+++ b/src/main/java/org/festimate/team/matching/dto/MatchingStatusResponse.java
@@ -1,0 +1,9 @@
+package org.festimate.team.matching.dto;
+
+import org.festimate.team.matching.entity.MatchingStatus;
+
+public record MatchingStatusResponse(
+        MatchingStatus status,
+        long matchingId
+) {
+}

--- a/src/main/java/org/festimate/team/matching/entity/Matching.java
+++ b/src/main/java/org/festimate/team/matching/entity/Matching.java
@@ -21,7 +21,7 @@ public class Matching extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer matchingId;
+    private Long matchingId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "festival_id", nullable = false)
@@ -32,7 +32,7 @@ public class Matching extends BaseTimeEntity {
     private Participant applicantParticipant;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "target_participant_id", nullable = false)
+    @JoinColumn(name = "target_participant_id")
     private Participant targetParticipant;
 
     @Column(nullable = false)
@@ -51,4 +51,11 @@ public class Matching extends BaseTimeEntity {
         this.status = status;
         this.matchDate = matchDate;
     }
+
+    public void completeMatching(Participant targetParticipant) {
+        this.targetParticipant = targetParticipant;
+        this.status = MatchingStatus.COMPLETED;
+        this.matchDate = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/org/festimate/team/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/festimate/team/matching/repository/MatchingRepository.java
@@ -1,0 +1,7 @@
+package org.festimate.team.matching.repository;
+
+import org.festimate.team.matching.entity.Matching;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchingRepository extends JpaRepository<Matching, Long> {
+}

--- a/src/main/java/org/festimate/team/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/festimate/team/matching/repository/MatchingRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
@@ -43,20 +44,28 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             @Param("festivalId") Long festivalId
     );
 
-
     @Query("""
                 SELECT m FROM Matching m
                 WHERE m.festival.festivalId = :festivalId
                   AND m.status = 'PENDING'
-                  AND m.applicantParticipant.typeResult = :typeResult
                   AND m.applicantParticipant.user.gender != :gender
                 ORDER BY m.createdAt ASC
-                LIMIT 1
             """)
-    Optional<Matching> findFirstPendingMatchingByTypeAndOppositeGender(
+    List<Matching> findAllPendingMatchingsByFestivalAndOppositeGender(
             @Param("festivalId") Long festivalId,
-            @Param("typeResult") TypeResult typeResult,
             @Param("gender") Gender gender
+    );
+
+    @Query("""
+                SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END
+                FROM Matching m
+                WHERE m.applicantParticipant.participantId = :participantId
+                  AND m.targetParticipant.participantId = :targetParticipantId
+                  AND m.status = 'COMPLETED'
+            """)
+    boolean existsCompletedMatching(
+            @Param("participantId") Long participantId,
+            @Param("targetParticipantId") Long targetParticipantId
     );
 
 }

--- a/src/main/java/org/festimate/team/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/festimate/team/matching/repository/MatchingRepository.java
@@ -1,7 +1,63 @@
 package org.festimate.team.matching.repository;
 
 import org.festimate.team.matching.entity.Matching;
+import org.festimate.team.participant.entity.Participant;
+import org.festimate.team.participant.entity.TypeResult;
+import org.festimate.team.user.entity.Gender;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
+    @Query("""
+                SELECT p FROM Participant p
+                WHERE p.festival.festivalId = :festivalId
+                  AND p.typeResult = :typeResult
+                  AND p.user.gender != :gender
+                  AND p.participantId != :participantId
+                  AND p.participantId NOT IN (
+                      SELECT m.targetParticipant.participantId FROM Matching m
+                      WHERE m.applicantParticipant.participantId = :participantId
+                        AND m.status = 'COMPLETED'
+                  )
+                  AND (SIZE(p.matchingsAsTarget) + SIZE(p.matchingsAsApplicant)) = (
+                      SELECT MIN(SIZE(p2.matchingsAsTarget) + SIZE(p2.matchingsAsApplicant))
+                      FROM Participant p2
+                      WHERE p2.festival.festivalId = :festivalId
+                        AND p2.typeResult = :typeResult
+                        AND p2.user.gender != :gender
+                        AND p2.participantId != :participantId
+                        AND p2.participantId NOT IN (
+                            SELECT m2.targetParticipant.participantId FROM Matching m2
+                            WHERE m2.applicantParticipant.participantId = :participantId
+                              AND m2.status = 'COMPLETED'
+                        )
+                  )
+            """)
+    Optional<Participant> findMatchingCandidate(
+            @Param("participantId") Long participantId,
+            @Param("typeResult") TypeResult typeResult,
+            @Param("gender") Gender gender,
+            @Param("festivalId") Long festivalId
+    );
+
+
+    @Query("""
+                SELECT m FROM Matching m
+                WHERE m.festival.festivalId = :festivalId
+                  AND m.status = 'PENDING'
+                  AND m.applicantParticipant.typeResult = :typeResult
+                  AND m.applicantParticipant.user.gender != :gender
+                ORDER BY m.createdAt ASC
+                LIMIT 1
+            """)
+    Optional<Matching> findFirstPendingMatchingByTypeAndOppositeGender(
+            @Param("festivalId") Long festivalId,
+            @Param("typeResult") TypeResult typeResult,
+            @Param("gender") Gender gender
+    );
+
 }
+

--- a/src/main/java/org/festimate/team/matching/service/MatchingService.java
+++ b/src/main/java/org/festimate/team/matching/service/MatchingService.java
@@ -1,4 +1,15 @@
 package org.festimate.team.matching.service;
 
+import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.matching.entity.Matching;
+import org.festimate.team.participant.entity.Participant;
+
+import java.util.Optional;
+
 public interface MatchingService {
+    Matching createMatching(Festival festival, Optional<Participant> targetParticipantOptional, Participant participant);
+
+    Optional<Participant> findMatchingCandidate(long festivalId, Participant participant);
+
+    void matchPendingParticipants(Participant newParticipant);
 }

--- a/src/main/java/org/festimate/team/matching/service/MatchingService.java
+++ b/src/main/java/org/festimate/team/matching/service/MatchingService.java
@@ -3,13 +3,15 @@ package org.festimate.team.matching.service;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.matching.entity.Matching;
 import org.festimate.team.participant.entity.Participant;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 public interface MatchingService {
     Matching createMatching(Festival festival, Optional<Participant> targetParticipantOptional, Participant participant);
-
-    Optional<Participant> findMatchingCandidate(long festivalId, Participant participant);
+    
+    @Transactional
+    Optional<Participant> findBestCandidateByPriority(long festivalId, Participant participant);
 
     void matchPendingParticipants(Participant newParticipant);
 }

--- a/src/main/java/org/festimate/team/matching/service/MatchingService.java
+++ b/src/main/java/org/festimate/team/matching/service/MatchingService.java
@@ -1,0 +1,4 @@
+package org.festimate.team.matching.service;
+
+public interface MatchingService {
+}

--- a/src/main/java/org/festimate/team/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/matching/service/impl/MatchingServiceImpl.java
@@ -2,11 +2,56 @@ package org.festimate.team.matching.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.matching.entity.Matching;
+import org.festimate.team.matching.entity.MatchingStatus;
+import org.festimate.team.matching.repository.MatchingRepository;
 import org.festimate.team.matching.service.MatchingService;
+import org.festimate.team.participant.entity.Participant;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class MatchingServiceImpl implements MatchingService {
+    private final MatchingRepository matchingRepository;
+
+    @Override
+    @Transactional
+    public Matching createMatching(Festival festival, Optional<Participant> targetParticipantOptional, Participant participant) {
+        Matching matching;
+
+        if (targetParticipantOptional.isEmpty()) {
+            matching = Matching.builder().festival(festival).applicantParticipant(participant).targetParticipant(null).status(MatchingStatus.PENDING).matchDate(LocalDateTime.now()).build();
+        } else {
+            matching = Matching.builder().festival(festival).applicantParticipant(participant).targetParticipant(targetParticipantOptional.get()).status(MatchingStatus.COMPLETED).matchDate(LocalDateTime.now()).build();
+        }
+
+        return matchingRepository.save(matching);
+    }
+
+    @Override
+    public Optional<Participant> findMatchingCandidate(long festivalId, Participant participant) {
+        return matchingRepository.findMatchingCandidate(participant.getParticipantId(), participant.getTypeResult(), participant.getUser().getGender(), festivalId);
+    }
+
+    @Transactional
+    @Override
+    public void matchPendingParticipants(Participant newParticipant) {
+        Optional<Matching> pendingMatchingOptional = matchingRepository.findFirstPendingMatchingByTypeAndOppositeGender(
+                newParticipant.getFestival().getFestivalId(),
+                newParticipant.getTypeResult(),
+                newParticipant.getUser().getGender()
+        );
+
+        pendingMatchingOptional.ifPresent(pendingMatching -> {
+            pendingMatching.completeMatching(newParticipant);
+        });
+    }
+
+
 }

--- a/src/main/java/org/festimate/team/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/matching/service/impl/MatchingServiceImpl.java
@@ -8,10 +8,14 @@ import org.festimate.team.matching.entity.MatchingStatus;
 import org.festimate.team.matching.repository.MatchingRepository;
 import org.festimate.team.matching.service.MatchingService;
 import org.festimate.team.participant.entity.Participant;
+import org.festimate.team.participant.entity.TypeResult;
+import org.festimate.team.user.entity.Gender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -34,24 +38,66 @@ public class MatchingServiceImpl implements MatchingService {
         return matchingRepository.save(matching);
     }
 
+    @Transactional
     @Override
-    public Optional<Participant> findMatchingCandidate(long festivalId, Participant participant) {
-        return matchingRepository.findMatchingCandidate(participant.getParticipantId(), participant.getTypeResult(), participant.getUser().getGender(), festivalId);
+    public Optional<Participant> findBestCandidateByPriority(long festivalId, Participant participant) {
+        List<TypeResult> priorities = MATCHING_PRIORITIES.get(participant.getTypeResult());
+        Gender myGender = participant.getUser().getGender();
+
+        for (TypeResult priorityType : priorities) {
+            Optional<Participant> candidate = matchingRepository.findMatchingCandidate(
+                    participant.getParticipantId(),
+                    priorityType,
+                    myGender,
+                    festivalId
+            );
+            if (candidate.isPresent()) {
+                return candidate;
+            }
+        }
+
+        return Optional.empty();
     }
 
     @Transactional
     @Override
     public void matchPendingParticipants(Participant newParticipant) {
-        Optional<Matching> pendingMatchingOptional = matchingRepository.findFirstPendingMatchingByTypeAndOppositeGender(
+        List<Matching> pendingMatchings = matchingRepository.findAllPendingMatchingsByFestivalAndOppositeGender(
                 newParticipant.getFestival().getFestivalId(),
-                newParticipant.getTypeResult(),
                 newParticipant.getUser().getGender()
         );
 
-        pendingMatchingOptional.ifPresent(pendingMatching -> {
-            pendingMatching.completeMatching(newParticipant);
-        });
+        for (Matching pendingMatching : pendingMatchings) {
+            Participant applicant = pendingMatching.getApplicantParticipant();
+
+            if (isValidMatch(applicant, newParticipant)) {
+                pendingMatching.completeMatching(newParticipant);
+                matchingRepository.save(pendingMatching);
+            }
+        }
     }
 
+    private boolean isValidMatch(Participant applicant, Participant candidate) {
+        List<TypeResult> priorities = MATCHING_PRIORITIES.get(applicant.getTypeResult());
+
+        if (!priorities.contains(candidate.getTypeResult())) {
+            return false;
+        }
+
+        boolean alreadyMatched = matchingRepository.existsCompletedMatching(
+                applicant.getParticipantId(),
+                candidate.getParticipantId()
+        );
+
+        return !alreadyMatched;
+    }
+
+    private static final Map<TypeResult, List<TypeResult>> MATCHING_PRIORITIES = Map.of(
+            TypeResult.INFLUENCER, List.of(TypeResult.PHOTO, TypeResult.INFLUENCER, TypeResult.NEWBIE, TypeResult.PLANNER, TypeResult.HEALING),
+            TypeResult.NEWBIE, List.of(TypeResult.PLANNER, TypeResult.NEWBIE, TypeResult.HEALING, TypeResult.INFLUENCER, TypeResult.PHOTO),
+            TypeResult.PHOTO, List.of(TypeResult.INFLUENCER, TypeResult.PHOTO, TypeResult.PLANNER, TypeResult.HEALING, TypeResult.NEWBIE),
+            TypeResult.PLANNER, List.of(TypeResult.NEWBIE, TypeResult.HEALING, TypeResult.INFLUENCER, TypeResult.PHOTO, TypeResult.PLANNER),
+            TypeResult.HEALING, List.of(TypeResult.HEALING, TypeResult.PLANNER, TypeResult.PHOTO, TypeResult.NEWBIE, TypeResult.INFLUENCER)
+    );
 
 }

--- a/src/main/java/org/festimate/team/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/matching/service/impl/MatchingServiceImpl.java
@@ -1,0 +1,12 @@
+package org.festimate.team.matching.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.matching.service.MatchingService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MatchingServiceImpl implements MatchingService {
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] 매칭 추가하기 API 기능 구현

## 📌 PR 내용
- 매칭 로직을 기존 "동일 유형 매칭"에서 `유형 우선순위 기반 매칭`으로 전환하였습니다.
- 사용자가 매칭을 신청하면, 본인의 페스티메이트 유형에 따라 정의된 우선순위에 따라 상대를 찾아 매칭합니다.
- 조건에 맞는 상대가 없을 경우, PENDING 상태로 매칭이 보류되며, 이후 새로운 이성이 들어올 경우 해당 보류 매칭을 자동으로 해결합니다.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/1e16c3cb-c57d-4136-b026-44a0eae2c650" />


### 📘 주요 흐름 요약
```
1. 클라이언트가 요청 → 컨트롤러 → 파사드 → 서비스 계층 진입
2. 참가자 정보 조회 → 포인트 차감
3. 매칭 우선순위 순회하며 가능한 이성 있는지 판단
4. 있다면 바로 매칭 → 없다면 보류로 저장
5. 결과를 MatchingStatusResponse로 반환
```

## 🛠 작업 내용
- [x] 매칭 우선순위 정의 및 적용 (TypeResult → List<TypeResult> Map 도입)
- [x] 우선순위 기반 반복 매칭 시도 로직 구현
- [x] 보류 매칭 상태 자동 해결을 위한 matchPendingParticipants() 개선
- [x] 중복 매칭 방지를 위한 existsCompletedMatching() 쿼리 적용
- [x] 매칭 시 포인트 차감 로직 유지
- [x] 기존 매칭 쿼리 재활용하여 최소 수정
- [x] 복잡한 조건을 만족하는 상대 참가자 쿼리(findMatchingCandidate()) 작성
```
같은 축제 내, 다른 성별이면서 내 타입 우선순위에 해당하고,
이미 나와 매칭된 적이 없으며,
현재 매칭 수가 가장 적은 상대를 조건으로 선별함
```
```java
@Query("""
    SELECT p FROM Participant p
    WHERE p.festival.festivalId = :festivalId
      AND p.typeResult = :typeResult
      AND p.user.gender != :gender
      AND p.participantId != :participantId
      AND p.participantId NOT IN (
          SELECT m.targetParticipant.participantId FROM Matching m
          WHERE m.applicantParticipant.participantId = :participantId
            AND m.status = 'COMPLETED'
      )
      AND (SIZE(p.matchingsAsTarget) + SIZE(p.matchingsAsApplicant)) = (
          SELECT MIN(SIZE(p2.matchingsAsTarget) + SIZE(p2.matchingsAsApplicant))
          FROM Participant p2
          WHERE p2.festival.festivalId = :festivalId
            AND p2.typeResult = :typeResult
            AND p2.user.gender != :gender
            AND p2.participantId != :participantId
            AND p2.participantId NOT IN (
                SELECT m2.targetParticipant.participantId FROM Matching m2
                WHERE m2.applicantParticipant.participantId = :participantId
                  AND m2.status = 'COMPLETED'
            )
      )
""")
Optional<Participant> findMatchingCandidate(...);

```
- [x] PENDING 매칭 중 특정 성별 상대를 빠르게 찾기 위한 쿼리(findAllPendingMatchingsByFestivalAndOppositeGender()) 작성
```java
@Query("""
    SELECT m FROM Matching m
    WHERE m.festival.festivalId = :festivalId
      AND m.status = 'PENDING'
      AND m.applicantParticipant.user.gender != :gender
    ORDER BY m.createdAt ASC
""")
List<Matching> findAllPendingMatchingsByFestivalAndOppositeGender(...);

```
## 🔍 관련 이슈
Closes #54 

## 📸 스크린샷 (Optional)
<img width="636" alt="image" src="https://github.com/user-attachments/assets/e86f4777-0684-4458-a59c-646e639fa085" />

## 📚 레퍼런스 (Optional)
N/A