### PR TITLE
[feat] #58 매칭 상세조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -8,6 +8,7 @@ import org.festimate.team.exception.FestimateException;
 import org.festimate.team.festival.dto.*;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.festival.service.FestivalService;
+import org.festimate.team.matching.dto.MatchingDetailResponse;
 import org.festimate.team.matching.dto.MatchingInfo;
 import org.festimate.team.matching.dto.MatchingListResponse;
 import org.festimate.team.matching.dto.MatchingStatusResponse;
@@ -130,6 +131,14 @@ public class FestivalFacade {
 
         List<MatchingInfo> matchings = matchingService.getMatchingListByParticipant(participant);
         return MatchingListResponse.from(matchings);
+    }
+
+    public MatchingDetailResponse getMatchingDetail(Long userId, long festivalId, long matchingId) {
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        Participant participant = getExistingParticipantOrThrow(userId, festival);
+
+        Matching matching = matchingService.getMatchingDetailById(participant, matchingId);
+        return MatchingDetailResponse.from(matching);
     }
 
     private Participant createParticipantIfValid(User user, Festival festival, ProfileRequest request) {

--- a/src/main/java/org/festimate/team/matching/controller/MatchingController.java
+++ b/src/main/java/org/festimate/team/matching/controller/MatchingController.java
@@ -5,6 +5,7 @@ import org.festimate.team.common.response.ApiResponse;
 import org.festimate.team.common.response.ResponseBuilder;
 import org.festimate.team.facade.FestivalFacade;
 import org.festimate.team.global.jwt.JwtService;
+import org.festimate.team.matching.dto.MatchingDetailResponse;
 import org.festimate.team.matching.dto.MatchingListResponse;
 import org.festimate.team.matching.dto.MatchingStatusResponse;
 import org.festimate.team.matching.service.MatchingService;
@@ -38,6 +39,18 @@ public class MatchingController {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
 
         MatchingListResponse response = festivalFacade.getMatchingList(userId, festivalId);
+        return ResponseBuilder.ok(response);
+    }
+
+    @GetMapping("/{festivalId}/matchings/{matchingId}")
+    public ResponseEntity<ApiResponse<MatchingDetailResponse>> getMatchingDetail(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @PathVariable("matchingId") Long matchingId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+
+        MatchingDetailResponse response = festivalFacade.getMatchingDetail(userId, festivalId, matchingId);
         return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/matching/dto/MatchingDetailResponse.java
+++ b/src/main/java/org/festimate/team/matching/dto/MatchingDetailResponse.java
@@ -1,0 +1,33 @@
+package org.festimate.team.matching.dto;
+
+import org.festimate.team.matching.entity.Matching;
+import org.festimate.team.participant.entity.Participant;
+import org.festimate.team.participant.entity.TypeResult;
+import org.festimate.team.user.entity.AppearanceType;
+import org.festimate.team.user.entity.Gender;
+import org.festimate.team.user.entity.Mbti;
+
+public record MatchingDetailResponse(
+        String nickname,
+        Gender gender,
+        Integer birthYear,
+        Mbti mbti,
+        AppearanceType appearance,
+        TypeResult typeResult,
+        String introduction,
+        String message
+) {
+    public static MatchingDetailResponse from(Matching matching) {
+        Participant participant = matching.getTargetParticipant();
+        return new MatchingDetailResponse(
+                participant.getUser().getNickname(),
+                participant.getUser().getGender(),
+                participant.getUser().getBirthYear(),
+                participant.getUser().getMbti(),
+                participant.getUser().getAppearanceType(),
+                participant.getTypeResult(),
+                participant.getIntroduction(),
+                participant.getMessage()
+        );
+    }
+}

--- a/src/main/java/org/festimate/team/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/festimate/team/matching/repository/MatchingRepository.java
@@ -75,5 +75,6 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             """)
     List<Matching> findAllMatchingsByApplicantParticipant(Participant participant);
 
+    Optional<Matching> findMatchingByMatchingId(Long matchingId);
 }
 

--- a/src/main/java/org/festimate/team/matching/service/MatchingService.java
+++ b/src/main/java/org/festimate/team/matching/service/MatchingService.java
@@ -18,4 +18,6 @@ public interface MatchingService {
     void matchPendingParticipants(Participant newParticipant);
 
     List<MatchingInfo> getMatchingListByParticipant(Participant participant);
+
+    Matching getMatchingDetailById(Participant participant, long matchingId);
 }

--- a/src/main/java/org/festimate/team/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/matching/service/impl/MatchingServiceImpl.java
@@ -2,6 +2,8 @@ package org.festimate.team.matching.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.common.response.ResponseError;
+import org.festimate.team.exception.FestimateException;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.matching.dto.MatchingInfo;
 import org.festimate.team.matching.entity.Matching;
@@ -84,6 +86,17 @@ public class MatchingServiceImpl implements MatchingService {
         return matchings.stream()
                 .map(MatchingInfo::fromMatching)
                 .toList();
+    }
+
+    @Override
+    public Matching getMatchingDetailById(Participant participant, long matchingId) {
+        Matching matching = matchingRepository.findMatchingByMatchingId(matchingId)
+                .orElseThrow(() -> new FestimateException(ResponseError.TARGET_NOT_FOUND));
+
+        if(matching.getApplicantParticipant() != participant){
+            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
+        }
+        return matching;
     }
 
     private boolean isValidMatch(Participant applicant, Participant candidate) {


### PR DESCRIPTION
## 📌 PR 제목
[feat] #58 매칭 상세조회 API 기능 구현

## 📌 PR 내용
- 성공한 매칭의 상세 정보를 조회하는 API 기능을 구현했습니다.

## 🛠 작업 내용
- [x] 성공한 매칭의 상세정보 조회
- [x] 잘못된 아이디를 보냈을 경우 에러 발생
- [x] 조회하려는 사람의 아이디가 매칭 신청 아이디가 아닐 경우 에러 발생

### ✅ MatchingService 테스트 코드 정리
테스트 메서드 이름 | 설명 | 검증 포인트 | 예외 처리 여부
-- | -- | -- | --
getMatchingDetailByMatchingId_success() | 매칭 신청자가 매칭 상세를 조회 | 매칭 ID가 일치하고 상세 정보 반환 | ❌
getMatchingDetailByMatchingId_Participant() | 매칭 신청자가 아닌 유저가 매칭 상세를 조회 | 예외: FORBIDDEN_RESOURCE 발생 | ✅
getMatchingDetailByMatchingId_empty() | 존재하지 않는 매칭 ID로 조회 시 | 예외: TARGET_NOT_FOUND 발생 | ✅

#### 📌 주요 예외
1. FestimateException 발생 케이스를 테스트하여 안전한 도메인 동작 보장
2. 매칭 요청자 본인만 상세 정보를 조회할 수 있음
3. 존재하지 않는 매칭 ID는 예외 처리됨


## 🔍 관련 이슈
Closes #58 

## 📸 스크린샷 (Optional)
<img width="676" alt="image" src="https://github.com/user-attachments/assets/58ea8c83-3c4a-429c-9f00-2a706684ed4e" />

## 📚 레퍼런스 (Optional)
N/A