### PR TITLE
[feat] #61 내가 생성한 페스티벌 리스트 조회 기능 구현 및 테스트 추가

### DIFF
--- a/src/main/java/org/festimate/team/facade/UserFacade.java
+++ b/src/main/java/org/festimate/team/facade/UserFacade.java
@@ -1,0 +1,22 @@
+package org.festimate.team.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.festimate.team.common.response.ResponseError;
+import org.festimate.team.exception.FestimateException;
+import org.festimate.team.user.entity.User;
+import org.festimate.team.user.repository.UserRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class UserFacade {
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> new FestimateException(ResponseError.USER_NOT_FOUND)
+        );
+    }
+}

--- a/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.festimate.team.common.response.ApiResponse;
 import org.festimate.team.common.response.ResponseBuilder;
 import org.festimate.team.facade.FestivalFacade;
+import org.festimate.team.facade.UserFacade;
+import org.festimate.team.festival.dto.AdminFestivalResponse;
 import org.festimate.team.festival.dto.FestivalRequest;
 import org.festimate.team.festival.dto.FestivalResponse;
 import org.festimate.team.festival.entity.Festival;
@@ -20,9 +22,10 @@ import java.util.List;
 public class AdminFestivalController {
     private final FestivalService festivalService;
     private final FestivalFacade festivalFacade;
+    private final UserFacade userFacade;
     private final JwtService jwtService;
 
-    @PostMapping
+    @PostMapping("/festival")
     public ResponseEntity<ApiResponse<FestivalResponse>> createFestival(
             @RequestHeader("Authorization") String accessToken,
             @RequestBody FestivalRequest request
@@ -33,9 +36,19 @@ public class AdminFestivalController {
         return ResponseBuilder.created(response);
     }
 
-    @GetMapping
-    public ResponseEntity<List<Festival>> getAllFestivals() {
-        List<Festival> festivals = festivalService.getAllFestivals();
-        return ResponseEntity.ok(festivals);
+    @GetMapping("/festivals")
+    public ResponseEntity<ApiResponse<List<AdminFestivalResponse>>> getAllFestivals(
+            @RequestHeader("Authorization") String accessToken
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+
+        List<Festival> festivals = festivalService.getAllFestivals(
+                userFacade.getUserById(userId)
+        );
+
+        List<AdminFestivalResponse> response = festivals.stream()
+                .map(AdminFestivalResponse::of)
+                .toList();
+        return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/festival/dto/AdminFestivalResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/AdminFestivalResponse.java
@@ -1,0 +1,20 @@
+package org.festimate.team.festival.dto;
+
+import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.festival.entity.FestivalStatus;
+
+public record AdminFestivalResponse(
+        long festivalId,
+        FestivalStatus status,
+        String title,
+        String inviteCode
+) {
+    public static AdminFestivalResponse of(Festival festival) {
+        return new AdminFestivalResponse(
+                festival.getFestivalId(),
+                festival.getFestivalStatus(),
+                festival.getTitle(),
+                festival.getInviteCode()
+        );
+    }
+}

--- a/src/main/java/org/festimate/team/festival/entity/Festival.java
+++ b/src/main/java/org/festimate/team/festival/entity/Festival.java
@@ -60,4 +60,20 @@ public class Festival extends BaseTimeEntity {
         this.endDate = endDate;
         this.inviteCode = inviteCode;
     }
+
+    public FestivalStatus getFestivalStatus() {
+        LocalDate now = LocalDate.now();
+        LocalDate startDate = this.getStartDate();
+        LocalDate endDate = this.getEndDate();
+
+        if (now.isBefore(startDate)) {
+            return FestivalStatus.BEFORE;
+        } else if (now.isBefore(endDate.plusDays(1))) {
+            return FestivalStatus.PROGRESS;
+        } else if (now.isBefore(endDate.plusDays(8))) {
+            return FestivalStatus.REFUND;
+        } else {
+            return FestivalStatus.END;
+        }
+    }
 }

--- a/src/main/java/org/festimate/team/festival/entity/FestivalStatus.java
+++ b/src/main/java/org/festimate/team/festival/entity/FestivalStatus.java
@@ -1,0 +1,8 @@
+package org.festimate.team.festival.entity;
+
+public enum FestivalStatus {
+    BEFORE,
+    PROGRESS,
+    END,
+    REFUND
+}

--- a/src/main/java/org/festimate/team/festival/repository/FestivalRepository.java
+++ b/src/main/java/org/festimate/team/festival/repository/FestivalRepository.java
@@ -1,8 +1,10 @@
 package org.festimate.team.festival.repository;
 
 import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FestivalRepository extends JpaRepository<Festival, Integer> {
@@ -11,4 +13,6 @@ public interface FestivalRepository extends JpaRepository<Festival, Integer> {
     Optional<Festival> findByInviteCode(String inviteCode);
 
     Optional<Festival> findByFestivalId(Long festivalId);
+
+    List<Festival> findFestivalByHost(User host);
 }

--- a/src/main/java/org/festimate/team/festival/service/FestivalService.java
+++ b/src/main/java/org/festimate/team/festival/service/FestivalService.java
@@ -13,7 +13,7 @@ public interface FestivalService {
 
     Festival getFestivalByIdOrThrow(Long festivalId);
 
-    List<Festival> getAllFestivals();
+    List<Festival> getAllFestivals(User user);
 
     boolean isFestivalExpired(Festival festival);
 }

--- a/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
+++ b/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
@@ -58,8 +58,9 @@ public class FestivalServiceImpl implements FestivalService {
     }
 
     @Override
-    public List<Festival> getAllFestivals() {
-        return festivalRepository.findAll();
+    public List<Festival> getAllFestivals(User user) {
+        log.info("user: {}", user);
+        return festivalRepository.findFestivalByHost(user);
     }
 
     @Override

--- a/src/test/java/org/festimate/team/common/mock/MockFactory.java
+++ b/src/test/java/org/festimate/team/common/mock/MockFactory.java
@@ -1,0 +1,54 @@
+package org.festimate.team.common.mock;
+
+import org.festimate.team.festival.entity.Category;
+import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.participant.entity.Participant;
+import org.festimate.team.participant.entity.TypeResult;
+import org.festimate.team.user.entity.*;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+public class MockFactory {
+
+    public static User mockUser(String nickname, Gender gender, long id) {
+        User user = User.builder()
+                .name("테스트유저")
+                .phoneNumber("010-1234-5678")
+                .nickname(nickname)
+                .birthYear(1999)
+                .gender(gender)
+                .mbti(Mbti.INFP)
+                .appearanceType(AppearanceType.BEAR)
+                .platformId("123456")
+                .platform(Platform.KAKAO)
+                .refreshToken("mock_refresh_token")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", id);
+        return user;
+    }
+
+    public static Festival mockFestival(User host, long id, LocalDate startDate, LocalDate endDate) {
+        Festival festival = Festival.builder()
+                .host(host)
+                .title("모의 페스티벌")
+                .category(Category.LIFE)
+                .startDate(startDate)
+                .endDate(endDate)
+                .inviteCode("MOCK123")
+                .build();
+
+        ReflectionTestUtils.setField(festival, "festivalId", id);
+        return festival;
+    }
+
+    public static Participant mockParticipant(User user, Festival festival, TypeResult typeResult, long id) {
+        Participant participant = Participant.builder()
+                .user(user)
+                .festival(festival)
+                .typeResult(typeResult)
+                .build();
+        ReflectionTestUtils.setField(participant, "participantId", id);
+        return participant;
+    }
+}

--- a/src/test/java/org/festimate/team/festival/entity/FestivalTest.java
+++ b/src/test/java/org/festimate/team/festival/entity/FestivalTest.java
@@ -1,0 +1,82 @@
+package org.festimate.team.festival.entity;
+
+import org.festimate.team.user.entity.Gender;
+import org.festimate.team.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.festimate.team.common.mock.MockFactory.mockFestival;
+import static org.festimate.team.common.mock.MockFactory.mockUser;
+
+public class FestivalTest {
+
+    private final User mockHost = mockUser("호스트", Gender.MAN, 1L);
+
+    @Test
+    @DisplayName("페스티벌 시작 전 상태 확인")
+    void testFestivalStatus_before() {
+        // given
+        LocalDate now = LocalDate.now();
+        Festival festival = mockFestival(mockHost, 1L, now.plusDays(1), now.plusDays(2));
+
+        // when
+        FestivalStatus status = festival.getFestivalStatus();
+
+        // then
+        assertThat(status).isEqualTo(FestivalStatus.BEFORE);
+    }
+
+    @Test
+    @DisplayName("페스티벌 진행중 상태 확인")
+    void testFestivalStatus_progress() {
+        // given
+        LocalDate now = LocalDate.now();
+        Festival festival1 = mockFestival(mockHost, 1L, now.minusDays(1), now);
+        Festival festival2 = mockFestival(mockHost, 1L, now, now);
+        Festival festival3 = mockFestival(mockHost, 1L, now, now.plusDays(2));
+        Festival festival4 = mockFestival(mockHost, 1L, now.minusDays(1), now.plusDays(1));
+
+        // when
+        FestivalStatus status1 = festival1.getFestivalStatus();
+        FestivalStatus status2 = festival2.getFestivalStatus();
+        FestivalStatus status3 = festival3.getFestivalStatus();
+        FestivalStatus status4 = festival4.getFestivalStatus();
+
+        // then
+        assertThat(status1).isEqualTo(FestivalStatus.PROGRESS);
+        assertThat(status2).isEqualTo(FestivalStatus.PROGRESS);
+        assertThat(status3).isEqualTo(FestivalStatus.PROGRESS);
+        assertThat(status4).isEqualTo(FestivalStatus.PROGRESS);
+    }
+
+    @Test
+    @DisplayName("페스티벌 환불 기간 상태 확인")
+    void testFestivalStatus_refund() {
+        // given
+        LocalDate now = LocalDate.now();
+        Festival festival = mockFestival(mockHost, 1L, now.minusDays(10), now.minusDays(7));
+
+        // when
+        FestivalStatus status = festival.getFestivalStatus();
+
+        // then
+        assertThat(status).isEqualTo(FestivalStatus.REFUND);
+    }
+
+    @Test
+    @DisplayName("페스티벌 종료 상태 확인")
+    void testFestivalStatus_end() {
+        // given
+        LocalDate now = LocalDate.now();
+        Festival festival = mockFestival(mockHost, 1L, now.minusDays(10), now.minusDays(8));
+
+        // when
+        FestivalStatus status = festival.getFestivalStatus();
+
+        // then
+        assertThat(status).isEqualTo(FestivalStatus.END);
+    }
+}

--- a/src/test/java/org/festimate/team/festival/service/FestivalServiceImplTest.java
+++ b/src/test/java/org/festimate/team/festival/service/FestivalServiceImplTest.java
@@ -1,0 +1,52 @@
+package org.festimate.team.festival.service;
+
+import org.festimate.team.common.mock.MockFactory;
+import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.festival.repository.FestivalRepository;
+import org.festimate.team.festival.service.impl.FestivalServiceImpl;
+import org.festimate.team.user.entity.Gender;
+import org.festimate.team.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+public class FestivalServiceImplTest {
+    @Mock
+    private FestivalRepository festivalRepository;
+
+    @InjectMocks
+    private FestivalServiceImpl festivalService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("호스트 유저가 개설한 모든 페스티벌 조회")
+    void getAllFestivals_success() {
+        // given
+        User host = MockFactory.mockUser("호스트", Gender.MAN, 1L);
+        Festival festival1 = MockFactory.mockFestival(host, 1L, LocalDate.now(), LocalDate.now().plusDays(2));
+        Festival festival2 = MockFactory.mockFestival(host, 2L, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
+        List<Festival> expectedFestivals = List.of(festival1, festival2);
+
+        when(festivalRepository.findFestivalByHost(host)).thenReturn(expectedFestivals);
+
+        // when
+        List<Festival> result = festivalService.getAllFestivals(host);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).containsExactly(festival1, festival2);
+    }
+}

--- a/src/test/java/org/festimate/team/matching/service/MatchingServiceImplTest.java
+++ b/src/test/java/org/festimate/team/matching/service/MatchingServiceImplTest.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.when;
 
-public class MatchingServiceTest {
+public class MatchingServiceImplTest {
     @Mock
     private MatchingRepository matchingRepository;
 

--- a/src/test/java/org/festimate/team/matching/service/MatchingServiceTest.java
+++ b/src/test/java/org/festimate/team/matching/service/MatchingServiceTest.java
@@ -1,4 +1,4 @@
-package org.festimate.team.matching;
+package org.festimate.team.matching.service;
 
 import org.festimate.team.festival.entity.Category;
 import org.festimate.team.festival.entity.Festival;

--- a/src/test/java/org/festimate/team/user/service/UserServiceImplTest.java
+++ b/src/test/java/org/festimate/team/user/service/UserServiceImplTest.java
@@ -1,6 +1,7 @@
-package org.festimate.team.user.service.impl;
+package org.festimate.team.user.service;
 
 import org.festimate.team.common.response.ResponseError;
+import org.festimate.team.user.service.impl.UserServiceImpl;
 import org.festimate.team.user.validator.NicknameValidator;
 import org.festimate.team.exception.FestimateException;
 import org.festimate.team.user.repository.UserRepository;


### PR DESCRIPTION
## 📌 PR 제목
[feat] #61 내가 개설한 페스티벌 전체 조회 API 기능 구현

## 📌 PR 내용
- 호스트 유저가 본인이 생성한 페스티벌 리스트를 조회할 수 있는 기능을 구현하고, 해당 도메인 및 서비스 레벨의 테스트 코드를 추가했습니다.

## 🛠 작업 내용
1. 기능 구현
```
FestivalService.getAllFestivals(User user) 구현
→ 호스트 유저가 생성한 페스티벌 리스트를 반환
```
```
AdminFestivalController.getAllFestivals() API 구현
→ JWT 토큰을 통해 유저 인증 후, 페스티벌 리스트를 반환
```
```
AdminFestivalResponse DTO 생성
→ 페스티벌 ID, 이름, 초대 코드, 상태 정보 포함
```

2. 도메인 설계
```
FestivalStatus enum 생성 (BEFORE, PROGRESS, REFUND, END)
```
```
Festival.getFestivalStatus() 메서드 구현
→ 현재 시각 기준으로 상태 계산 로직 도메인에 위치
```
3. 테스트 코드 추가
```
FestivalServiceTest에 getAllFestivals() 단위 테스트 작성
```
```
FestivalTest에 도메인 상태 판단 로직 테스트
```
```
공용 mock 생성 유틸: MockFactory 클래스 생성
→ User, Festival, Participant mock 객체 생성용 정적 메서드 제공
```

## 🔍 관련 이슈
Closes #61 

## 📸 스크린샷 (Optional)
<img width="642" alt="image" src="https://github.com/user-attachments/assets/80f9a224-ecf3-4d57-985a-28a8f2982f77" />

## 📚 레퍼런스 (Optional)
N/A