### PR TITLE
[feat] #64 어드민 페이지의 페스티벌 상세조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/common/util/DateFormatter.java
+++ b/src/main/java/org/festimate/team/common/util/DateFormatter.java
@@ -1,0 +1,16 @@
+package org.festimate.team.common.util;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class DateFormatter {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    public static String formatPeriod(LocalDate startDate, LocalDate endDate) {
+        return startDate.format(FORMATTER) + " ~ " + endDate.format(FORMATTER);
+    }
+
+    public static String formatSingle(LocalDate date) {
+        return date.format(FORMATTER);
+    }
+}

--- a/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
@@ -5,6 +5,7 @@ import org.festimate.team.common.response.ApiResponse;
 import org.festimate.team.common.response.ResponseBuilder;
 import org.festimate.team.facade.FestivalFacade;
 import org.festimate.team.facade.UserFacade;
+import org.festimate.team.festival.dto.AdminFestivalDetailResponse;
 import org.festimate.team.festival.dto.AdminFestivalResponse;
 import org.festimate.team.festival.dto.FestivalRequest;
 import org.festimate.team.festival.dto.FestivalResponse;
@@ -49,6 +50,18 @@ public class AdminFestivalController {
         List<AdminFestivalResponse> response = festivals.stream()
                 .map(AdminFestivalResponse::of)
                 .toList();
+        return ResponseBuilder.ok(response);
+    }
+
+    @GetMapping("/festivals/{festivalId}")
+    public ResponseEntity<ApiResponse<AdminFestivalDetailResponse>> getFestivalDetail(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable Long festivalId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        AdminFestivalDetailResponse response
+                = AdminFestivalDetailResponse.of(festivalService.getFestivalDetailByIdOrThrow(festivalId, userId));
+
         return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/festival/dto/AdminFestivalDetailResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/AdminFestivalDetailResponse.java
@@ -1,0 +1,22 @@
+package org.festimate.team.festival.dto;
+
+import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.festival.entity.FestivalStatus;
+
+import static org.festimate.team.common.util.DateFormatter.formatPeriod;
+
+public record AdminFestivalDetailResponse(
+        FestivalStatus status,
+        String title,
+        String festivalDate,
+        String inviteCode
+) {
+    public static AdminFestivalDetailResponse of(Festival festival) {
+        return new AdminFestivalDetailResponse(
+                festival.getFestivalStatus(),
+                festival.getTitle(),
+                formatPeriod(festival.getStartDate(), festival.getEndDate()),
+                festival.getInviteCode()
+        );
+    }
+}

--- a/src/main/java/org/festimate/team/festival/dto/FestivalInfoResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/FestivalInfoResponse.java
@@ -2,8 +2,7 @@ package org.festimate.team.festival.dto;
 
 import org.festimate.team.festival.entity.Festival;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import static org.festimate.team.common.util.DateFormatter.formatPeriod;
 
 public record FestivalInfoResponse(
         String festivalName,
@@ -12,12 +11,7 @@ public record FestivalInfoResponse(
     public static FestivalInfoResponse of(Festival festival) {
         return new FestivalInfoResponse(
                 festival.getTitle(),
-                formattingDate(festival.getStartDate(), festival.getEndDate())
+                formatPeriod(festival.getStartDate(), festival.getEndDate())
         );
-    }
-
-    private static String formattingDate(LocalDate startDate, LocalDate endDate) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
-        return startDate.format(formatter) + " ~ " + endDate.format(formatter);
     }
 }

--- a/src/main/java/org/festimate/team/festival/service/FestivalService.java
+++ b/src/main/java/org/festimate/team/festival/service/FestivalService.java
@@ -15,5 +15,7 @@ public interface FestivalService {
 
     List<Festival> getAllFestivals(User user);
 
+    Festival getFestivalDetailByIdOrThrow(Long festivalId, Long userId);
+
     boolean isFestivalExpired(Festival festival);
 }

--- a/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
+++ b/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 @Service
@@ -61,6 +62,15 @@ public class FestivalServiceImpl implements FestivalService {
     public List<Festival> getAllFestivals(User user) {
         log.info("user: {}", user);
         return festivalRepository.findFestivalByHost(user);
+    }
+
+    @Override
+    public Festival getFestivalDetailByIdOrThrow(Long festivalId, Long userId) {
+        Festival festival = getFestivalByIdOrThrow(festivalId);
+        if (!Objects.equals(festival.getHost().getUserId(), userId)) {
+            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
+        }
+        return festival;
     }
 
     @Override


### PR DESCRIPTION
## 📌 PR 제목
[feat] #64 어드민 페이지의 페스티벌 상세조회 API 기능 구현

## 📌 PR 내용
- 어드민이 본인이 생성한 페스티벌의 상세 정보를 조회할 수 있는 기능을 추가했습니다.
- 요청한 유저가 해당 페스티벌의 host가 아닌 경우 FORBIDDEN_RESOURCE 예외를 반환합니다.

## 🛠 작업 내용
- [x] 어드민 페이지의 페스티벌 상세조회 API 기능 구현
- [x] 본인 확인 로직 추가 (userId와 hostId 비교)
- [x] 존재하지 않는 페스티벌 조회 시 에러 발생

## 🔍 관련 이슈
Closes #64 

## 📸 스크린샷 (Optional)
<img width="629" alt="image" src="https://github.com/user-attachments/assets/ce566fda-6b87-4219-9cbc-d78e758335dd" />

## 📚 레퍼런스 (Optional)
N/A