### PR TITLE
[feat] #66 어드민 페이지에서 특정 유저의 포인트 조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/common/response/ResponseError.java
+++ b/src/main/java/org/festimate/team/common/response/ResponseError.java
@@ -28,6 +28,7 @@ public enum ResponseError {
     TARGET_NOT_FOUND(4040, "대상을 찾을 수 없습니다."),
     USER_NOT_FOUND(4041, "존재하지 않는 회원입니다."),
     FESTIVAL_NOT_FOUND(4042, "존재하지 않는 페스티벌입니다."),
+    PARTICIPANT_NOT_FOUND(4043, "존재하지 않는 참가자입니다."),
 
     // Method Not Allowed (405)
     METHOD_NOT_ALLOWED(4050, "잘못된 HTTP method 요청입니다."),

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -111,8 +111,19 @@ public class FestivalFacade {
         return pointService.getPointHistory(participant);
     }
 
+    @Transactional(readOnly = true)
+    public PointHistoryResponse getParticipantPointHistory(Long userId, Long festivalId, Long participantId) {
+        User user = userService.getUserById(userId);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        if (!festivalService.isHost(user, festival)) {
+            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
+        }
+        Participant participant = participantService.getParticipantById(participantId);
+        return pointService.getPointHistory(participant);
+    }
+
     @Transactional
-    public MatchingStatusResponse createMatching(Long userId, long festivalId) {
+    public MatchingStatusResponse createMatching(Long userId, Long festivalId) {
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
         Participant participant = getExistingParticipantOrThrow(userId, festival);
 

--- a/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
@@ -1,6 +1,7 @@
 package org.festimate.team.festival.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.festimate.team.Point.dto.PointHistoryResponse;
 import org.festimate.team.common.response.ApiResponse;
 import org.festimate.team.common.response.ResponseBuilder;
 import org.festimate.team.facade.FestivalFacade;
@@ -49,6 +50,19 @@ public class AdminFestivalController {
         List<AdminFestivalResponse> response = festivals.stream()
                 .map(AdminFestivalResponse::of)
                 .toList();
+        return ResponseBuilder.ok(response);
+    }
+
+    @GetMapping("/festivals/{festivalId}/participants/{participantId}/points")
+    public ResponseEntity<ApiResponse<PointHistoryResponse>> getParticipantPointHistory(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @PathVariable("participantId") Long participantId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+
+        PointHistoryResponse response = festivalFacade.getParticipantPointHistory(userId, festivalId, participantId);
+
         return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
@@ -2,7 +2,6 @@ package org.festimate.team.festival.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.festimate.team.Point.dto.PointHistoryResponse;
-import org.festimate.team.Point.dto.PointHistoryResponse;
 import org.festimate.team.common.response.ApiResponse;
 import org.festimate.team.common.response.ResponseBuilder;
 import org.festimate.team.facade.FestivalFacade;

--- a/src/main/java/org/festimate/team/festival/service/FestivalService.java
+++ b/src/main/java/org/festimate/team/festival/service/FestivalService.java
@@ -16,4 +16,6 @@ public interface FestivalService {
     List<Festival> getAllFestivals(User user);
 
     boolean isFestivalExpired(Festival festival);
+
+    boolean isHost(User user, Festival festival);
 }

--- a/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
+++ b/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
@@ -69,6 +69,12 @@ public class FestivalServiceImpl implements FestivalService {
         return festival.getEndDate().isAfter(LocalDate.now());
     }
 
+    @Override
+    public boolean isHost(User user, Festival festival) {
+        log.info("user is: {}, host is {}", user, festival.getHost());
+        return festival.getHost().equals(user);
+    }
+
     private String generateUniqueInviteCode() {
         Random random = new Random();
         String inviteCode;

--- a/src/main/java/org/festimate/team/participant/repository/ParticipantRepository.java
+++ b/src/main/java/org/festimate/team/participant/repository/ParticipantRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDate;
 import java.util.List;
 
-public interface ParticipantRepository extends JpaRepository<Participant, Integer> {
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
     Participant getParticipantByUserAndFestival(User user, Festival festival);
 
     @Query("SELECT p FROM Participant p WHERE p.user = :user AND " +

--- a/src/main/java/org/festimate/team/participant/service/ParticipantService.java
+++ b/src/main/java/org/festimate/team/participant/service/ParticipantService.java
@@ -17,6 +17,8 @@ public interface ParticipantService {
 
     Participant getParticipant(User user, Festival festival);
 
+    Participant getParticipantById(Long participantId);
+
     @Transactional(readOnly = true)
     List<Festival> getFestivalsByUser(User user, String status);
 

--- a/src/main/java/org/festimate/team/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/org/festimate/team/participant/service/impl/ParticipantServiceImpl.java
@@ -2,6 +2,8 @@ package org.festimate.team.participant.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.common.response.ResponseError;
+import org.festimate.team.exception.FestimateException;
 import org.festimate.team.festival.dto.TypeRequest;
 import org.festimate.team.festival.dto.TypeResponse;
 import org.festimate.team.festival.entity.Festival;
@@ -41,6 +43,13 @@ public class ParticipantServiceImpl implements ParticipantService {
     @Override
     public Participant getParticipant(User user, Festival festival) {
         return participantRepository.getParticipantByUserAndFestival(user, festival);
+    }
+
+    @Override
+    public Participant getParticipantById(Long participantId) {
+        return participantRepository.findById(participantId).orElseThrow(
+                () -> new FestimateException(ResponseError.PARTICIPANT_NOT_FOUND)
+        );
     }
 
     @Override


### PR DESCRIPTION
## 📌 PR 제목
[feat] #66 어드민 페이지에서 특정 유저의 포인트 조회 API 기능 구현

## 📌 PR 내용
- 어드민(페스티벌 개설자)이 특정 페스티벌 참가자의 포인트 이력을 조회할 수 있는 API를 추가했습니다.
- 해당 API는 참가자의 포인트 히스토리를 상세히 확인하기 위한 용도로 사용됩니다.
- 본인 인증 및 호스트 권한 확인 로직도 함께 포함되어 있습니다.


## 🛠 작업 내용
- [x] FestivalFacade.getParticipantPointHistory() 로직 구현
- [x] 본인 확인 및 host 권한 검증
- [x] 참가자 ID 기반 조회를 위한 ParticipantService.getParticipantById() 메서드 사용
- [x] 포인트 이력 응답을 위한 PointHistoryResponse 반환



## 🔍 관련 이슈
Closes #66 

## 📸 스크린샷 (Optional)
<img width="653" alt="image" src="https://github.com/user-attachments/assets/262bd899-9af1-4956-9cd9-283b756590c2" />

## 📚 레퍼런스 (Optional)
추가로 공유할 정보가 있다면 여기에 작성해주세요.
N/A