### PR TITLE
[feat] #68 닉네임으로 유저 검색 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -115,11 +115,18 @@ public class FestivalFacade {
     public PointHistoryResponse getParticipantPointHistory(Long userId, Long festivalId, Long participantId) {
         User user = userService.getUserById(userId);
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
-        if (!festivalService.isHost(user, festival)) {
-            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
-        }
+        isHost(user, festival);
         Participant participant = participantService.getParticipantById(participantId);
         return pointService.getPointHistory(participant);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SearchParticipantResponse> getParticipantByNickname(Long userId, Long festivalId, String nickname) {
+        User user = userService.getUserById(userId);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        isHost(user, festival);
+        List<Participant> participants = participantService.getParticipantByNickname(festival, nickname);
+        return SearchParticipantResponse.from(participants);
     }
 
     @Transactional
@@ -165,5 +172,11 @@ public class FestivalFacade {
 
     private Participant getParticipantInfo(User user, Festival festival) {
         return participantService.getParticipant(user, festival);
+    }
+
+    private void isHost(User user, Festival festival) {
+        if (!festivalService.isHost(user, festival)) {
+            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
+        }
     }
 }

--- a/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
@@ -6,10 +6,7 @@ import org.festimate.team.common.response.ApiResponse;
 import org.festimate.team.common.response.ResponseBuilder;
 import org.festimate.team.facade.FestivalFacade;
 import org.festimate.team.facade.UserFacade;
-import org.festimate.team.festival.dto.AdminFestivalDetailResponse;
-import org.festimate.team.festival.dto.AdminFestivalResponse;
-import org.festimate.team.festival.dto.FestivalRequest;
-import org.festimate.team.festival.dto.FestivalResponse;
+import org.festimate.team.festival.dto.*;
 import org.festimate.team.festival.entity.Festival;
 import org.festimate.team.festival.service.FestivalService;
 import org.festimate.team.global.jwt.JwtService;
@@ -76,6 +73,18 @@ public class AdminFestivalController {
 
         PointHistoryResponse response = festivalFacade.getParticipantPointHistory(userId, festivalId, participantId);
 
+        return ResponseBuilder.ok(response);
+    }
+
+    @GetMapping("/festivals/{festivalId}/participants/search")
+    public ResponseEntity<ApiResponse<List<SearchParticipantResponse>>> getParticipantByNickname(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @RequestParam("nickname") String nickname
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+
+        List<SearchParticipantResponse> response = festivalFacade.getParticipantByNickname(userId, festivalId, nickname);
         return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/festival/dto/SearchParticipantResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/SearchParticipantResponse.java
@@ -1,0 +1,28 @@
+package org.festimate.team.festival.dto;
+
+import org.festimate.team.participant.entity.Participant;
+
+import java.util.List;
+
+public record SearchParticipantResponse(
+        long participantId,
+        String name,
+        String nickname,
+        String phone
+) {
+    public static SearchParticipantResponse from(Participant participant) {
+        return new SearchParticipantResponse(
+                participant.getParticipantId(),
+                participant.getUser().getName(),
+                participant.getUser().getNickname(),
+                participant.getUser().getPhoneNumber()
+        );
+    }
+
+    public static List<SearchParticipantResponse> from(List<Participant> participants) {
+        return participants.stream()
+                .sorted((p1, p2) -> p2.getCreatedAt().compareTo(p1.getCreatedAt()))
+                .map(SearchParticipantResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/org/festimate/team/participant/repository/ParticipantRepository.java
+++ b/src/main/java/org/festimate/team/participant/repository/ParticipantRepository.java
@@ -5,7 +5,6 @@ import org.festimate.team.participant.entity.Participant;
 import org.festimate.team.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -18,6 +17,5 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
             ":status = 'END' AND p.festival.endDate < :today)")
     List<Participant> findAllByUser(User user, String status, LocalDate today);
 
-    @Query("SELECT COALESCE(SUM(p.point), 0) FROM Point p WHERE p.participant = :participant")
-    int getTotalPointByParticipant(@Param("participant") Participant participant);
+    List<Participant> findAllByFestivalAndUser_NicknameContaining(Festival festival, String nickname);
 }

--- a/src/main/java/org/festimate/team/participant/service/ParticipantService.java
+++ b/src/main/java/org/festimate/team/participant/service/ParticipantService.java
@@ -22,5 +22,7 @@ public interface ParticipantService {
     @Transactional(readOnly = true)
     List<Festival> getFestivalsByUser(User user, String status);
 
+    List<Participant> getParticipantByNickname(Festival festival, String nickname);
+
     TypeResponse getTypeResult(TypeRequest request);
 }

--- a/src/main/java/org/festimate/team/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/org/festimate/team/participant/service/impl/ParticipantServiceImpl.java
@@ -61,6 +61,16 @@ public class ParticipantServiceImpl implements ParticipantService {
     }
 
     @Override
+    public List<Participant> getParticipantByNickname(Festival festival, String nickname) {
+        log.info("닉네임 검색 요청 - festivalId: {}, nickname: {}", festival.getFestivalId(), nickname);
+
+        List<Participant> result = participantRepository.findAllByFestivalAndUser_NicknameContaining(festival, nickname);
+
+        log.info("닉네임 검색 결과 개수: {}", result.size());
+        return result;
+    }
+
+    @Override
     public TypeResponse getTypeResult(TypeRequest typeRequest) {
         int[][] weights = new int[5][];
         weights[0] = typeRequest.q1() ? new int[]{3, 1, 1, -1, -1} : new int[]{-3, -1, -1, 1, 1};


### PR DESCRIPTION
## 📌 PR 제목
[feat] #68 닉네임으로 유저 검색 API 기능 구현

## 📌 PR 내용
- 어드민 페이지에서 특정 페스티벌의 참가자 중, 닉네임으로 유저를 검색하는 API를 구현했습니다.
- 닉네임은 부분 일치로 검색되며, 대소문자를 구분하지 않습니다.
- 검색어가 비어 있을 경우 해당 페스티벌의 모든 참가자를 반환합니다.

## 🛠 작업 내용
- [x] 닉네임이 포함된 참가자 리스트 응답 DTO 구현
- [x] 빈 문자열일 경우 전체 참가자 반환 로직 처리
- [x] 호스트가 아닌 사람이 검색할 경우 에러 발생

## 🔍 관련 이슈
Closes #68 

## 📸 스크린샷 (Optional)
<img width="632" alt="image" src="https://github.com/user-attachments/assets/2bb65971-ee21-4765-bf14-0e23a40a440d" />

## 📚 레퍼런스 (Optional)
N/A