### PR TITLE
[feat] #70 포인트 충전하기 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/Point/service/PointService.java
+++ b/src/main/java/org/festimate/team/Point/service/PointService.java
@@ -11,4 +11,7 @@ public interface PointService {
 
     @Transactional
     void usePoint(Participant participant);
+
+    @Transactional
+    void rechargePoint(Participant participant, int amount);
 }

--- a/src/main/java/org/festimate/team/Point/service/impl/PointServiceImpl.java
+++ b/src/main/java/org/festimate/team/Point/service/impl/PointServiceImpl.java
@@ -43,13 +43,22 @@ public class PointServiceImpl implements PointService {
             throw new FestimateException(ResponseError.INSUFFICIENT_POINTS);
         }
 
-        Point pointUsage = Point.builder()
-                .participant(participant)
-                .point(1)
-                .transactionType(TransactionType.DEBIT)
-                .build();
-
+        Point pointUsage = createPointTransaction(participant, 1, TransactionType.DEBIT);
         pointRepository.save(pointUsage);
     }
 
+    @Transactional
+    @Override
+    public void rechargePoint(Participant participant, int amount) {
+        Point pointUsage = createPointTransaction(participant, amount, TransactionType.CREDIT);
+        pointRepository.save(pointUsage);
+    }
+
+    private Point createPointTransaction(Participant participant, int amount, TransactionType type) {
+        return Point.builder()
+                .participant(participant)
+                .point(amount)
+                .transactionType(type)
+                .build();
+    }
 }

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -130,6 +130,19 @@ public class FestivalFacade {
     }
 
     @Transactional
+    public void rechargePoints(Long userId, Long festivalId, RechargePointRequest request) {
+        User user = userService.getUserById(userId);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        isHost(user, festival);
+
+        Participant participant = participantService.getParticipantById(request.participantId());
+        if (participant.getFestival() != festival) {
+            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
+        }
+        pointService.rechargePoint(participant, request.point());
+    }
+
+    @Transactional
     public MatchingStatusResponse createMatching(Long userId, Long festivalId) {
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
         Participant participant = getExistingParticipantOrThrow(userId, festival);

--- a/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
+++ b/src/main/java/org/festimate/team/festival/controller/AdminFestivalController.java
@@ -87,4 +87,16 @@ public class AdminFestivalController {
         List<SearchParticipantResponse> response = festivalFacade.getParticipantByNickname(userId, festivalId, nickname);
         return ResponseBuilder.ok(response);
     }
+
+    @PostMapping("/festival/{festivalId}/points")
+    public ResponseEntity<ApiResponse<FestivalResponse>> rechargePoints(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @RequestBody RechargePointRequest request
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        festivalFacade.rechargePoints(userId, festivalId, request);
+
+        return ResponseBuilder.created(null);
+    }
 }

--- a/src/main/java/org/festimate/team/festival/dto/RechargePointRequest.java
+++ b/src/main/java/org/festimate/team/festival/dto/RechargePointRequest.java
@@ -1,0 +1,7 @@
+package org.festimate.team.festival.dto;
+
+public record RechargePointRequest(
+        long participantId,
+        int point
+) {
+}

--- a/src/test/java/org/festimate/team/festival/service/AdminFestivalServiceImplTest.java
+++ b/src/test/java/org/festimate/team/festival/service/AdminFestivalServiceImplTest.java
@@ -1,0 +1,105 @@
+package org.festimate.team.festival.service;
+
+import org.festimate.team.Point.service.PointService;
+import org.festimate.team.common.mock.MockFactory;
+import org.festimate.team.exception.FestimateException;
+import org.festimate.team.facade.FestivalFacade;
+import org.festimate.team.festival.dto.RechargePointRequest;
+import org.festimate.team.festival.entity.Festival;
+import org.festimate.team.participant.entity.Participant;
+import org.festimate.team.participant.service.ParticipantService;
+import org.festimate.team.user.entity.Gender;
+import org.festimate.team.user.entity.User;
+import org.festimate.team.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AdminFestivalServiceImplTest {
+    @Mock
+    private UserService userService;
+    @Mock
+    private FestivalService festivalService;
+    @Mock
+    private ParticipantService participantService;
+    @Mock
+    private PointService pointService;
+
+    @InjectMocks
+    private FestivalFacade festivalFacade;
+
+    private User host;
+    private User targetUser;
+    private Festival festival;
+    private Participant participant;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        host = MockFactory.mockUser("호스트", Gender.MAN, 1L);
+        targetUser = MockFactory.mockUser("참가자", Gender.WOMAN, 2L);
+        festival = MockFactory.mockFestival(host, 100L, LocalDate.now(), LocalDate.now().plusDays(2));
+        participant = MockFactory.mockParticipant(targetUser, festival, null, 200L);
+    }
+
+    @Test
+    @DisplayName("포인트 충전 - 정상 케이스")
+    void rechargePoints_success() {
+        // given
+        RechargePointRequest request = new RechargePointRequest(participant.getParticipantId(), 5);
+
+        when(userService.getUserById(1L)).thenReturn(host);
+        when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
+        when(festivalService.isHost(host, festival)).thenReturn(true);
+        when(participantService.getParticipantById(200L)).thenReturn(participant);
+
+        // when
+        festivalFacade.rechargePoints(1L, 100L, request);
+
+        // then
+        verify(pointService).rechargePoint(participant, 5);
+    }
+
+    @Test
+    @DisplayName("포인트 충전 - 요청자가 호스트가 아님")
+    void rechargePoints_notHost_throws() {
+        User attacker = MockFactory.mockUser("악당", Gender.MAN, 999L);
+        RechargePointRequest request = new RechargePointRequest(participant.getParticipantId(), 5);
+
+        when(userService.getUserById(999L)).thenReturn(attacker);
+        when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
+        when(festivalService.isHost(attacker, festival)).thenReturn(false);
+
+        assertThatThrownBy(() ->
+                festivalFacade.rechargePoints(999L, 100L, request)
+        ).isInstanceOf(FestimateException.class);
+    }
+
+    @Test
+    @DisplayName("포인트 충전 - 참가자가 해당 페스티벌 소속 아님")
+    void rechargePoints_participantMismatch_throws() {
+        Festival otherFestival = MockFactory.mockFestival(host, 999L, LocalDate.now(), LocalDate.now().plusDays(1));
+        Participant otherParticipant = MockFactory.mockParticipant(targetUser, otherFestival, null, 300L);
+
+        RechargePointRequest request = new RechargePointRequest(otherParticipant.getParticipantId(), 5);
+
+        when(userService.getUserById(1L)).thenReturn(host);
+        when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
+        when(festivalService.isHost(host, festival)).thenReturn(true);
+        when(participantService.getParticipantById(300L)).thenReturn(otherParticipant);
+
+        assertThatThrownBy(() ->
+                festivalFacade.rechargePoints(1L, 100L, request)
+        ).isInstanceOf(FestimateException.class);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] #70 포인트 충전하기 API 기능 구현

## 📌 PR 내용
- 어드민 페이지에서 사용자의 포인트를 충전하는 API 기능을 구현했습니다.
- 호스트가 아닌 사용자가 요청하거나, 대상 유저가 해당 페스티벌의 참가자가 아닌 경우 예외가 발생합니다.

## 🛠 작업 내용
- [x] RechargePointRequest DTO 정의 (충전 대상 및 포인트 수량 포함)
- [x] FestivalFacade.rechargePoints(...) 로직 구현
- [x] 충전 요청자의 호스트 여부 검증
- [x] 대상 유저의 참가자 여부 및 페스티벌 일치 여부 검증
- [x] 포인트 충전 기록 생성 (TransactionType: CREDIT)
- [x] 단위 테스트 작성 (정상 충전, 비호스트 요청, 참가자 미일치 등)

## 🔍 관련 이슈
Closes #69 

## 📸 스크린샷 (Optional)
<img width="675" alt="image" src="https://github.com/user-attachments/assets/7fd68c2d-976e-4ec0-add4-e9522f04561a" />

## 📚 레퍼런스 (Optional)
N/A