### PR TITLE
[fix] #84 카카오 플랫폼 아이디 발급 로직 수정

### DIFF
--- a/src/main/java/org/festimate/team/auth/controller/AuthController.java
+++ b/src/main/java/org/festimate/team/auth/controller/AuthController.java
@@ -24,11 +24,11 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<TokenResponse>> login(
-            @RequestHeader("Authorization") String authorization
+            @RequestHeader("Authorization") String kakaoAccessToken
     ) {
-        log.info("social login - Code: {}", authorization);
+        log.info("social login - Code: {}", kakaoAccessToken);
 
-        String platformId = loginFacade.getPlatformId(authorization);
+        String platformId = loginFacade.getPlatformId(kakaoAccessToken);
 
         return userService.getUserIdByPlatformAndPlatformId(Platform.KAKAO, platformId)
                 .map(userId -> loginFacade.login(platformId, Platform.KAKAO))

--- a/src/main/java/org/festimate/team/auth/infra/service/KakaoLoginService.java
+++ b/src/main/java/org/festimate/team/auth/infra/service/KakaoLoginService.java
@@ -15,9 +15,9 @@ public class KakaoLoginService {
 
     @Transactional
     public String getKakaoPlatformId(String accessToken) {
-        String kakaoAccessToken = kakaoOAuthClient.getAccessToken(accessToken);
-        log.info("kakaoAccessToken: {}", kakaoAccessToken);
+        // String kakaoAccessToken = kakaoOAuthClient.getAccessToken(accessToken);
+        log.info("kakaoAccessToken: {}", accessToken);
 
-        return kakaoOAuthClient.getPlatformId(kakaoAccessToken);
+        return kakaoOAuthClient.getPlatformId(accessToken);
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
[fix] #84 카카오 플랫폼 아이디 발급 로직 수정

## 📌 PR 내용
- 카카오 플랫폼 아이디 발급 로직을 수정했습니다.

## 🛠 작업 내용
- [x] 카카오 액세스 토큰 발급 로직 삭제
- [x] 카카오 플랫폼 아이디 발급 시 프론트에서 보내는 카카오 액세스 토큰 활용

## 🔍 관련 이슈
Closes #84 

## 📸 스크린샷 (Optional)
N/A

## 📚 레퍼런스 (Optional)
N/A