### PR TITLE
[chore] #87 메인 화면 닉네임 조회 API 응답 필드 오타(nickanme) → nickname 수정

### DIFF
--- a/src/main/java/org/festimate/team/user/dto/UserNicknameResponse.java
+++ b/src/main/java/org/festimate/team/user/dto/UserNicknameResponse.java
@@ -1,9 +1,9 @@
 package org.festimate.team.user.dto;
 
 public record UserNicknameResponse(
-        String nickanme
+        String nickname
 ) {
-    public static UserNicknameResponse from(String nickanme) {
-        return new UserNicknameResponse(nickanme);
+    public static UserNicknameResponse from(String nickname) {
+        return new UserNicknameResponse(nickname);
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
[chore] 메인 화면 닉네임 조회 API 응답 필드 오타(nickanme) → nickname 수정

## 📌 PR 내용
- 오타 수정: 응답 JSON 중 nickanme → nickname 으로 변경
- DTO 반영: UserNicknameResponse 레코드 필드 및 from() 정적 팩토리 메서드에 동일 변경 적용
- API 문서 수정

## 🛠 작업 내용
Before | After
-- | --
{"nickanme":"개죽이"} | {"nickname":"개죽이"}

## 🔍 관련 이슈
Closes #87 

## 📸 스크린샷 (Optional)
<img width="628" alt="image" src="https://github.com/user-attachments/assets/05e75b53-64d6-499a-9a87-c4d46c3142fd" />

## 📚 레퍼런스 (Optional)
N/A