### PR TITLE
[fix] #89 매칭 알고리즘 우선순위 탐색 범위 축소 및 테스트 코드 추가

### DIFF
--- a/src/main/java/org/festimate/team/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/matching/service/impl/MatchingServiceImpl.java
@@ -102,11 +102,10 @@ public class MatchingServiceImpl implements MatchingService {
     }
 
     private static final Map<TypeResult, List<TypeResult>> MATCHING_PRIORITIES = Map.of(
-            TypeResult.INFLUENCER, List.of(TypeResult.PHOTO, TypeResult.INFLUENCER, TypeResult.NEWBIE, TypeResult.PLANNER, TypeResult.HEALING),
-            TypeResult.NEWBIE, List.of(TypeResult.PLANNER, TypeResult.NEWBIE, TypeResult.HEALING, TypeResult.INFLUENCER, TypeResult.PHOTO),
-            TypeResult.PHOTO, List.of(TypeResult.INFLUENCER, TypeResult.PHOTO, TypeResult.PLANNER, TypeResult.HEALING, TypeResult.NEWBIE),
-            TypeResult.PLANNER, List.of(TypeResult.NEWBIE, TypeResult.HEALING, TypeResult.INFLUENCER, TypeResult.PHOTO, TypeResult.PLANNER),
-            TypeResult.HEALING, List.of(TypeResult.HEALING, TypeResult.PLANNER, TypeResult.PHOTO, TypeResult.NEWBIE, TypeResult.INFLUENCER)
+            TypeResult.INFLUENCER, List.of(TypeResult.PHOTO, TypeResult.INFLUENCER, TypeResult.NEWBIE),
+            TypeResult.NEWBIE, List.of(TypeResult.PLANNER, TypeResult.NEWBIE, TypeResult.HEALING),
+            TypeResult.PHOTO, List.of(TypeResult.INFLUENCER, TypeResult.PHOTO, TypeResult.PLANNER),
+            TypeResult.PLANNER, List.of(TypeResult.NEWBIE, TypeResult.HEALING, TypeResult.INFLUENCER),
+            TypeResult.HEALING, List.of(TypeResult.HEALING, TypeResult.PLANNER, TypeResult.PHOTO)
     );
-
 }


### PR DESCRIPTION
## 📌 PR 제목
[fix] #89 매칭 알고리즘 우선순위 탐색 범위 축소 및 테스트 코드 추가

## 📌 PR 내용
- 기존 매칭 알고리즘의 우선순위 탐색 범위를 15순위 → 13순위로 변경하였습니다.
- 변경된 우선순위 로직을 검증하기 위한 단위 테스트를 추가하였습니다.

## 🛠 작업 내용
- [x]  매칭 우선순위 Map 수정 (각 TypeResult에 대해 상위 3개 우선순위만 유지)
- [x] MatchingServiceImpl.findBestCandidateByPriority() 로직 변경 없음 (Map만 수정)
- [ ] 1~3순위 각각에서 후보 유무에 따라 매칭이 되는 테스트 코드 작성
- [ ]  1~3순위 모두 없을 경우 매칭 보류 처리되는 케이스 검증
- [ ] 이미 매칭된 상대는 재매칭되지 않도록 검증하는 테스트 포함

## 🔍 관련 이슈
Closes #89 

## 📸 스크린샷 (Optional)
<img width="664" alt="image" src="https://github.com/user-attachments/assets/4ebc9609-8b0a-48ca-8722-2dfd65222019" />

## 📚 레퍼런스 (Optional)
N/A