### PR TITLE
[fix] #91 매칭 시작 시각 도입 및 매칭 가능 시간 검증 기능 추가

### DIFF
--- a/src/main/java/org/festimate/team/common/response/ResponseError.java
+++ b/src/main/java/org/festimate/team/common/response/ResponseError.java
@@ -13,6 +13,7 @@ public enum ResponseError {
     INVALID_INPUT_NICKNAME(4004, "닉네임은 한글로만 입력 가능합니다."),
     INVALID_GRANT(4005, "유효하지 않은 인가 코드입니다."),
     INVALID_DATE_TYPE(4006, "유효하지 않은 날짜 형식입니다."),
+    INVALID_TIME_TYPE(4007, "유효하지 않은 시간입니다."),
 
     // Unauthorized (401)
     INVALID_ACCESS_TOKEN(4011, "액세스 토큰의 값이 올바르지 않습니다."),

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.festimate.team.festival.validator.DateValidator.isFestivalDateValid;
+import static org.festimate.team.festival.validator.DateValidator.isMatchingDateValid;
 import static org.festimate.team.festival.validator.FestivalRequestValidator.isFestivalValid;
 
 @Component
@@ -42,6 +43,7 @@ public class FestivalFacade {
 
         isFestivalValid(request.title(), request.category());
         isFestivalDateValid(request.startDate(), request.endDate());
+        isMatchingDateValid(request.startDate(), request.matchingStartAt());
 
         Festival festival = festivalService.createFestival(host, request);
 

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -82,12 +82,12 @@ public class FestivalFacade {
 
         int point = pointService.getTotalPointByParticipant(participant);
 
-        return MainUserInfoResponse.from(participant, point);
+        return MainUserInfoResponse.from(participant, point, festival.getMatchingStartTimeStatus());
     }
 
     public ProfileResponse getParticipantProfile(Long userId, Festival festival) {
         Participant participant = getExistingParticipantOrThrow(userId, festival);
-        return ProfileResponse.of(participant.getTypeResult(), participant.getUser().getNickname());
+        return ProfileResponse.of(participant.getTypeResult(), participant.getUser().getNickname(), festival.getMatchingStartTimeStatus());
     }
 
     public DetailProfileResponse getParticipantType(Long userId, Festival festival) {

--- a/src/main/java/org/festimate/team/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/facade/FestivalFacade.java
@@ -22,12 +22,14 @@ import org.festimate.team.user.service.UserService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.festimate.team.festival.validator.DateValidator.isFestivalDateValid;
-import static org.festimate.team.festival.validator.DateValidator.isMatchingDateValid;
+import static org.festimate.team.festival.validator.DateValidator.isMatchingStartTimeValid;
 import static org.festimate.team.festival.validator.FestivalRequestValidator.isFestivalValid;
+import static org.festimate.team.matching.validator.MatchingValidator.isMatchingDateValid;
 
 @Component
 @RequiredArgsConstructor
@@ -43,7 +45,7 @@ public class FestivalFacade {
 
         isFestivalValid(request.title(), request.category());
         isFestivalDateValid(request.startDate(), request.endDate());
-        isMatchingDateValid(request.startDate(), request.matchingStartAt());
+        isMatchingStartTimeValid(request.startDate(), request.matchingStartAt());
 
         Festival festival = festivalService.createFestival(host, request);
 
@@ -148,6 +150,8 @@ public class FestivalFacade {
     public MatchingStatusResponse createMatching(Long userId, Long festivalId) {
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
         Participant participant = getExistingParticipantOrThrow(userId, festival);
+
+        isMatchingDateValid(LocalDateTime.now(), festival.getMatchingStartAt());
 
         pointService.usePoint(participant);
 

--- a/src/main/java/org/festimate/team/festival/dto/FestivalRequest.java
+++ b/src/main/java/org/festimate/team/festival/dto/FestivalRequest.java
@@ -1,10 +1,12 @@
 package org.festimate.team.festival.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record FestivalRequest(
         String title,
         String category,
         LocalDate startDate,
-        LocalDate endDate
+        LocalDate endDate,
+        LocalDateTime matchingStartAt
 ){}

--- a/src/main/java/org/festimate/team/festival/dto/MainUserInfoResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/MainUserInfoResponse.java
@@ -1,16 +1,19 @@
 package org.festimate.team.festival.dto;
 
+import org.festimate.team.festival.entity.FestivalStatus;
 import org.festimate.team.participant.entity.Participant;
 import org.festimate.team.participant.entity.TypeResult;
 
 public record MainUserInfoResponse(
         TypeResult typeResult,
-        int point
+        int point,
+        FestivalStatus status
 ) {
-    public static MainUserInfoResponse from(Participant participant, int point) {
+    public static MainUserInfoResponse from(Participant participant, int point, FestivalStatus status) {
         return new MainUserInfoResponse(
                 participant.getTypeResult(),
-                point
+                point,
+                status
         );
     }
 }

--- a/src/main/java/org/festimate/team/festival/dto/ProfileResponse.java
+++ b/src/main/java/org/festimate/team/festival/dto/ProfileResponse.java
@@ -1,12 +1,14 @@
 package org.festimate.team.festival.dto;
 
+import org.festimate.team.festival.entity.FestivalStatus;
 import org.festimate.team.participant.entity.TypeResult;
 
 public record ProfileResponse(
         TypeResult typeResult,
-        String nickname
+        String nickname,
+        FestivalStatus status
 ) {
-    public static ProfileResponse of(TypeResult typeResult, String nickname) {
-        return new ProfileResponse(typeResult, nickname);
+    public static ProfileResponse of(TypeResult typeResult, String nickname, FestivalStatus status) {
+        return new ProfileResponse(typeResult, nickname, status);
     }
 }

--- a/src/main/java/org/festimate/team/festival/entity/Festival.java
+++ b/src/main/java/org/festimate/team/festival/entity/Festival.java
@@ -12,6 +12,7 @@ import org.festimate.team.user.entity.User;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -42,6 +43,9 @@ public class Festival extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDate endDate;
 
+    @Column(nullable = false)
+    private LocalDateTime matchingStartAt;
+
     @Column(nullable = false, unique = true)
     private String inviteCode;
 
@@ -52,12 +56,13 @@ public class Festival extends BaseTimeEntity {
     private List<Matching> matchings;
 
     @Builder
-    public Festival(User host, String title, Category category, LocalDate startDate, LocalDate endDate, String inviteCode) {
+    public Festival(User host, String title, Category category, LocalDate startDate, LocalDate endDate, LocalDateTime matchingStartAt, String inviteCode) {
         this.host = host;
         this.title = title;
         this.category = category;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.matchingStartAt = matchingStartAt;
         this.inviteCode = inviteCode;
     }
 

--- a/src/main/java/org/festimate/team/festival/entity/Festival.java
+++ b/src/main/java/org/festimate/team/festival/entity/Festival.java
@@ -81,4 +81,13 @@ public class Festival extends BaseTimeEntity {
             return FestivalStatus.END;
         }
     }
+
+    public FestivalStatus getMatchingStartTimeStatus() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime matchingStartAt = this.matchingStartAt;
+
+        if (now.isBefore(matchingStartAt)) {
+            return FestivalStatus.BEFORE;
+        } else return getFestivalStatus();
+    }
 }

--- a/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
+++ b/src/main/java/org/festimate/team/festival/service/impl/FestivalServiceImpl.java
@@ -36,6 +36,7 @@ public class FestivalServiceImpl implements FestivalService {
                 .category(Category.toCategory(request.category()))
                 .startDate(request.startDate())
                 .endDate(request.endDate())
+                .matchingStartAt(request.matchingStartAt())
                 .inviteCode(inviteCode)
                 .build();
 

--- a/src/main/java/org/festimate/team/festival/validator/DateValidator.java
+++ b/src/main/java/org/festimate/team/festival/validator/DateValidator.java
@@ -6,12 +6,39 @@ import org.festimate.team.exception.FestimateException;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Component
 @Slf4j
 public class DateValidator {
+    public static void isFestivalDateValid(final LocalDate startDateStr, final LocalDate endDateStr) {
+        log.info("Validating festival dates. startDate={}, endDate={}", startDateStr, endDateStr);
 
-    public static LocalDate parseAndValidateDate(final LocalDate date) {
+        LocalDate startDate = parseAndValidateDate(startDateStr);
+        LocalDate endDate = parseAndValidateDate(endDateStr);
+
+        if (startDate.isAfter(endDate)) {
+            log.warn("Invalid festival dates: startDate is after endDate");
+            throw new FestimateException(ResponseError.INVALID_DATE_TYPE);
+        }
+
+        log.info("Festival dates are valid.");
+    }
+
+    public static void isMatchingDateValid(final LocalDate startDateStr, final LocalDateTime matchingStartAt) {
+        log.info("Validating matchingStartAt. startDate={}, matchingStartAt={}", startDateStr, matchingStartAt);
+
+        LocalDateTime startTime = parseAndValidateTime(matchingStartAt);
+
+        if (startTime.toLocalDate().isBefore(startDateStr)) {
+            log.warn("Invalid matchingStartAt: matchingStartAt is before festival startDate");
+            throw new FestimateException(ResponseError.INVALID_TIME_TYPE);
+        }
+
+        log.info("matchingStartAt is valid.");
+    }
+
+    private static LocalDate parseAndValidateDate(final LocalDate date) {
         if (date == null) {
             throw new FestimateException(ResponseError.INVALID_DATE_TYPE);
         }
@@ -19,17 +46,12 @@ public class DateValidator {
         return date;
     }
 
-    public static void isFestivalDateValid(final LocalDate startDateStr, final LocalDate endDateStr) {
-        log.info("입력된 startDate: {}, endDate: {}", startDateStr, endDateStr);
-
-        LocalDate startDate = parseAndValidateDate(startDateStr);
-        LocalDate endDate = parseAndValidateDate(endDateStr);
-
-        if (startDate.isAfter(endDate)) {
-            throw new FestimateException(ResponseError.INVALID_DATE_TYPE);
+    private static LocalDateTime parseAndValidateTime(final LocalDateTime time) {
+        if (time == null) {
+            throw new FestimateException(ResponseError.INVALID_TIME_TYPE);
         }
 
-        log.info("날짜 검증 완료: startDate={}, endDate={}", startDate, endDate);
+        return time;
     }
 }
 

--- a/src/main/java/org/festimate/team/festival/validator/DateValidator.java
+++ b/src/main/java/org/festimate/team/festival/validator/DateValidator.java
@@ -25,7 +25,7 @@ public class DateValidator {
         log.info("Festival dates are valid.");
     }
 
-    public static void isMatchingDateValid(final LocalDate startDateStr, final LocalDateTime matchingStartAt) {
+    public static void isMatchingStartTimeValid(final LocalDate startDateStr, final LocalDateTime matchingStartAt) {
         log.info("Validating matchingStartAt. startDate={}, matchingStartAt={}", startDateStr, matchingStartAt);
 
         LocalDateTime startTime = parseAndValidateTime(matchingStartAt);

--- a/src/main/java/org/festimate/team/matching/validator/MatchingValidator.java
+++ b/src/main/java/org/festimate/team/matching/validator/MatchingValidator.java
@@ -1,0 +1,24 @@
+package org.festimate.team.matching.validator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.common.response.ResponseError;
+import org.festimate.team.exception.FestimateException;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@Slf4j
+public class MatchingValidator {
+
+    public static void isMatchingDateValid(final LocalDateTime requestMatchingTime, final LocalDateTime matchingStartAt) {
+        log.info("Validating requestMatchingTime. requestMatchingTime={}, matchingStartAt={}", requestMatchingTime, matchingStartAt);
+
+        if (requestMatchingTime.isBefore(matchingStartAt)) {
+            log.warn("Invalid requestMatchingTime: requestMatchingTime is before festival matchingStartAt");
+            throw new FestimateException(ResponseError.INVALID_TIME_TYPE);
+        }
+
+        log.info("matchingStartAt is valid.");
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
[fix] #91 매칭 시작 시각 도입 및 매칭 가능 시간 검증 기능 추가

## 📌 PR 내용
- 축제 개설 시 `matchingStartAt`을 설정할 수 있도록 필드를 추가하고, 해당 시간 이후에만 참가자가 매칭을 생성할 수 있도록 제한하는 로직을 도입했습니다.
- 클라이언트가 매칭 가능 여부를 판단할 수 있도록 `status: BEFORE | PROGRESS | REFUND` 값을 응답에 포함하는 로직도 함께 구현했습니다.

## 🛠 작업 내용
- [x] Festival 엔티티에 `matchingStartAt(LocalDateTime)` 필드 추가
- [x] Request DTO에 `matchingStartAt` 필드 추가 및 검증 로직 작성
- [x] 축제 시작일 이전에도 참가 가능하도록 입장 제한 완화
- [x] 매칭 생성 시 현재 시간이 `matchingStartAt` 이전이면 예외 반환
- [x] 응답에 현재 매칭 가능 상태(`BEFORE`, `PROGRESS`, `REFUND`) 포함
- [x] 매칭 시간 검증을 위한 `MatchingValidator` 작성
- [x] 시간 관련 에러 메시지 추가 (`"매칭 시작일 전에는 매칭을 시작할 수 없습니다."`)

## 🔍 관련 이슈
Closes #91 

## 📸 스크린샷 (Optional)

구분 | API 설명 | 확인된 매칭 상태 | 스크린샷
-- | -- | -- | --
1 | 어드민 페이지 – 페스티벌 생성 | Festival 정상 생성 및 matchingStartAt 반영 완료 |  ![image](https://github.com/user-attachments/assets/0e499c4b-b4a0-49e8-b26e-8d8ed9ef2ece)
2 | 마이페이지 – 프로필 조회 | 매칭 시작 전임을 정확히 판단 (status: BEFORE) |  ![image](https://github.com/user-attachments/assets/93f2a613-48c6-42e6-a6db-b77737d0577f)
3 | 페스티벌방 – 내 프로필 + 포인트 조회 | 매칭 전 상태에 맞는 응답 정상 반환 (status: BEFORE) |  ![image](https://github.com/user-attachments/assets/469e3912-5cce-4cc8-9cc9-d3ee1b2858c2)

## 📚 레퍼런스 (Optional)
N/A