### PR TITLE
[feat] #94 AOP 기반 API 요청 시작/종료 로깅 기능 추가

### DIFF
--- a/src/main/java/org/festimate/team/global/aop/LoggingAop.java
+++ b/src/main/java/org/festimate/team/global/aop/LoggingAop.java
@@ -1,0 +1,34 @@
+package org.festimate.team.global.aop;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAop {
+
+    @Before("@within(org.springframework.web.bind.annotation.RestController)")
+    public void logBefore(JoinPoint joinPoint) {
+        HttpServletRequest request =
+                ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        log.info("Start API Request: {} {}", request.getMethod(), request.getRequestURI());
+        log.info("Controller Method: {}", joinPoint.getSignature().getName());
+    }
+
+    @AfterReturning("@within(org.springframework.web.bind.annotation.RestController)")
+    public void logAfter() {
+        HttpServletRequest request =
+                ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        log.info("End API Request: {} {}", request.getMethod(), request.getRequestURI());
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] #94 AOP 기반 API 요청 시작/종료 로깅 기능 추가

## 📌 PR 내용
- 컨트롤러 단의 모든 API 요청에 대해 시작/종료 시점 로그를 출력하는 기능을 추가했습니다.
- API 흐름 추적 및 디버깅 편의성을 높이기 위한 목적입니다.

## 🛠 작업 내용
- [x] 기능 추가: LoggingAop 클래스 작성 및 AOP 기반 로깅 구현
- [x] 요청 시작 시 @Before를 통해 HTTP 메서드 + URI + 메서드명 로그 출력
- [x] 요청 정상 종료 시 @AfterReturning을 통해 종료 로그 출력
- [x] RequestContextHolder를 이용한 현재 요청 정보 추출

## 🔍 관련 이슈
Closes #94 

## 📸 스크린샷 (Optional)
<img width="487" alt="image" src="https://github.com/user-attachments/assets/d0bde65e-e57d-462a-9b41-20b9570494cd" />

## 📚 레퍼런스 (Optional)
N/A