### PR TITLE
[fix] #103 같은 유저의 중복 참가 방지 및 참가자 조회 로직 리팩토링

### DIFF
--- a/src/main/java/org/festimate/team/api/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/FestivalFacade.java
@@ -28,7 +28,7 @@ public class FestivalFacade {
 
     @Transactional(readOnly = true)
     public FestivalInfoResponse getFestivalInfo(Long userId, Long festivalId) {
-        User user = userService.getUserById(userId);
+        User user = userService.getUserByIdOrThrow(userId);
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
         participantService.validateParticipation(user, festival);
         return FestivalInfoResponse.of(festival);
@@ -36,7 +36,7 @@ public class FestivalFacade {
 
     @Transactional
     public FestivalResponse createFestival(Long userId, FestivalRequest request) {
-        User host = userService.getUserById(userId);
+        User host = userService.getUserByIdOrThrow(userId);
 
         festivalService.validateCreateFestival(request);
 
@@ -46,7 +46,7 @@ public class FestivalFacade {
 
     @Transactional(readOnly = true)
     public List<UserFestivalResponse> getUserFestivals(Long userId, String status) {
-        User user = userService.getUserById(userId);
+        User user = userService.getUserByIdOrThrow(userId);
         return participantService.getFestivalsByUser(user, status)
                 .stream()
                 .map(UserFestivalResponse::from)
@@ -55,7 +55,7 @@ public class FestivalFacade {
 
     @Transactional(readOnly = true)
     public List<AdminFestivalResponse> getAllFestivals(Long userId) {
-        User user = userService.getUserById(userId);
+        User user = userService.getUserByIdOrThrow(userId);
         List<Festival> festivals = festivalService.getAllFestivals(user);
         return festivals.stream()
                 .map(AdminFestivalResponse::of)

--- a/src/main/java/org/festimate/team/api/facade/ParticipantFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/ParticipantFacade.java
@@ -29,17 +29,17 @@ public class ParticipantFacade {
 
     @Transactional(readOnly = true)
     public EntryResponse entryFestival(Long userId, Long festivalId) {
-        User user = userService.getUserById(userId);
-        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
-        Participant participant = participantService.getParticipant(user, festival);
+        Participant participant = getParticipant(userId, festivalId);
         return EntryResponse.of(participant);
     }
 
     @Transactional
     public EntryResponse createParticipant(Long userId, Long festivalId, ProfileRequest request) {
-        User user = userService.getUserById(userId);
+        User user = userService.getUserByIdOrThrow(userId);
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
-
+        if (participantService.getParticipant(user, festival) != null) {
+            throw new FestimateException(ResponseError.PARTICIPANT_ALREADY_EXISTS);
+        }
         Participant participant = participantService.createParticipant(user, festival, request);
         matchingService.matchPendingParticipants(participant);
 
@@ -74,7 +74,7 @@ public class ParticipantFacade {
 
     @Transactional(readOnly = true)
     public Participant getParticipant(Long userId, Long festivalId) {
-        User user = userService.getUserById(userId);
+        User user = userService.getUserByIdOrThrow(userId);
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
         Participant participant = participantService.getParticipant(user, festival);
         if (participant == null) {
@@ -85,7 +85,7 @@ public class ParticipantFacade {
 
     @Transactional(readOnly = true)
     public List<SearchParticipantResponse> getParticipantByNickname(Long userId, Long festivalId, String nickname) {
-        User user = userService.getUserById(userId);
+        User user = userService.getUserByIdOrThrow(userId);
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
         isHost(user, festival);
         List<Participant> participants = participantService.getParticipantByNickname(festival, nickname);

--- a/src/main/java/org/festimate/team/api/facade/PointFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/PointFacade.java
@@ -33,7 +33,7 @@ public class PointFacade {
 
     @Transactional(readOnly = true)
     public PointHistoryResponse getParticipantPointHistory(Long userId, Long festivalId, Long participantId) {
-        User user = userService.getUserById(userId);
+        User user = userService.getUserByIdOrThrow(userId);
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
         isHost(user, festival);
         Participant participant = participantService.getParticipantById(participantId);
@@ -42,7 +42,7 @@ public class PointFacade {
 
     @Transactional
     public void rechargePoints(Long userId, Long festivalId, RechargePointRequest request) {
-        User user = userService.getUserById(userId);
+        User user = userService.getUserByIdOrThrow(userId);
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
         isHost(user, festival);
 
@@ -54,7 +54,7 @@ public class PointFacade {
     }
 
     private Participant getExistingParticipantOrThrow(Long userId, Festival festival) {
-        User user = userService.getUserById(userId);
+        User user = userService.getUserByIdOrThrow(userId);
         Participant participant = participantService.getParticipant(user, festival);
         if (participant == null) {
             throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -66,7 +66,7 @@ public class MatchingServiceImpl implements MatchingService {
 
     private Participant getExistingParticipantOrThrow(Long userId, Festival festival) {
         Participant participant = participantService.getParticipant(
-                userService.getUserById(userId), festival
+                userService.getUserByIdOrThrow(userId), festival
         );
         if (participant == null) {
             throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);

--- a/src/main/java/org/festimate/team/domain/user/service/UserService.java
+++ b/src/main/java/org/festimate/team/domain/user/service/UserService.java
@@ -17,7 +17,7 @@ public interface UserService {
 
     String getUserNickname(Long userId);
 
-    User getUserById(Long userId);
+    User getUserByIdOrThrow(Long userId);
 
     void validateRefreshToken(User user, String refreshToken);
 

--- a/src/main/java/org/festimate/team/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/user/service/impl/UserServiceImpl.java
@@ -51,12 +51,12 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public String getUserNickname(Long userId) {
-        getUserById(userId);
+        getUserByIdOrThrow(userId);
         return userRepository.findNicknameByUserId(userId);
     }
 
     @Override
-    public User getUserById(Long userId) {
+    public User getUserByIdOrThrow(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new FestimateException(ResponseError.USER_NOT_FOUND));
     }
@@ -69,7 +69,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void updateRefreshToken(Long userId, String refreshToken) {
-        User user = getUserById(userId);
+        User user = getUserByIdOrThrow(userId);
         user.updateRefreshToken(refreshToken);
         userRepository.save(user);
     }

--- a/src/main/java/org/festimate/team/infra/jwt/JwtService.java
+++ b/src/main/java/org/festimate/team/infra/jwt/JwtService.java
@@ -79,7 +79,7 @@ public class JwtService {
     @Transactional
     public TokenResponse reIssueToken(final String refreshToken) {
         Long userId = parseTokenAndGetUserId(refreshToken);
-        User findUser = userService.getUserById(userId);
+        User findUser = userService.getUserByIdOrThrow(userId);
         String extractPrefixToken = refreshToken.split(" ")[1];
         isValidRefreshToken(findUser, extractPrefixToken);
         String renewRefreshToken = createRefreshToken(userId);
@@ -100,7 +100,7 @@ public class JwtService {
             SecretKey secretKey = getSecretKey();
             Long userId = parseTokenAndGetUserId(secretKey, splitToken);
 
-            if (userService.getUserById(userId).getRefreshToken() == null) {
+            if (userService.getUserByIdOrThrow(userId).getRefreshToken() == null) {
                 throw new FestimateException(ResponseError.INVALID_TOKEN);
             }
             return userId;

--- a/src/test/java/org/festimate/team/api/facade/FestivalFacadeTest.java
+++ b/src/test/java/org/festimate/team/api/facade/FestivalFacadeTest.java
@@ -69,7 +69,7 @@ class FestivalFacadeTest {
         // given
         Festival festival = MockFactory.mockFestival(user, 1L, LocalDate.now(), LocalDate.now().plusDays(1));
 
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
 
         // user가 참가자인지 검증
@@ -97,7 +97,7 @@ class FestivalFacadeTest {
 
         Festival festival = MockFactory.mockFestival(user, 100L, request.startDate(), request.endDate());
 
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(festivalService.createFestival(user, request)).thenReturn(festival);
 
         // when
@@ -113,7 +113,7 @@ class FestivalFacadeTest {
         // given
         Festival festival = MockFactory.mockFestival(user, 200L, LocalDate.now(), LocalDate.now().plusDays(2));
 
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(participantService.getFestivalsByUser(user, "ALL")).thenReturn(List.of(festival));
 
         // when
@@ -131,7 +131,7 @@ class FestivalFacadeTest {
         Festival festival1 = MockFactory.mockFestival(user, 1L, LocalDate.now(), LocalDate.now().plusDays(1));
         Festival festival2 = MockFactory.mockFestival(user, 2L, LocalDate.now().minusDays(1), LocalDate.now().plusDays(2));
 
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(festivalService.getAllFestivals(user)).thenReturn(List.of(festival1, festival2));
 
         // when

--- a/src/test/java/org/festimate/team/api/facade/ParticipantFacadeTest.java
+++ b/src/test/java/org/festimate/team/api/facade/ParticipantFacadeTest.java
@@ -1,6 +1,7 @@
 package org.festimate.team.api.facade;
 
 import org.festimate.team.api.participant.dto.MessageRequest;
+import org.festimate.team.api.participant.dto.ProfileRequest;
 import org.festimate.team.common.mock.MockFactory;
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.service.FestivalService;
@@ -58,7 +59,7 @@ class ParticipantFacadeTest {
     @Test
     @DisplayName("참가자 입장 성공")
     void entryFestival_success() {
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
         when(participantService.getParticipant(user, festival)).thenReturn(participant);
 
@@ -70,7 +71,7 @@ class ParticipantFacadeTest {
     @Test
     @DisplayName("참가자 생성 성공")
     void createParticipant_success() {
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
         when(participantService.createParticipant(any(), any(), any())).thenReturn(participant);
 
@@ -83,7 +84,7 @@ class ParticipantFacadeTest {
     @Test
     @DisplayName("내 프로필 조회 성공")
     void getParticipantProfile_success() {
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
         when(participantService.getParticipant(user, festival)).thenReturn(participant);
 
@@ -95,7 +96,7 @@ class ParticipantFacadeTest {
     @Test
     @DisplayName("포인트 포함 요약정보 조회 성공")
     void getParticipantSummary_success() {
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
         when(participantService.getParticipant(user, festival)).thenReturn(participant);
         when(pointService.getTotalPointByParticipant(participant)).thenReturn(10);
@@ -108,7 +109,7 @@ class ParticipantFacadeTest {
     @Test
     @DisplayName("자세한 프로필 조회 성공")
     void getParticipantType_success() {
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
         when(participantService.getParticipant(user, festival)).thenReturn(participant);
 
@@ -120,7 +121,7 @@ class ParticipantFacadeTest {
     @Test
     @DisplayName("메시지 수정 성공")
     void modifyMessage_success() {
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
         when(participantService.getParticipant(user, festival)).thenReturn(participant);
 
@@ -135,12 +136,32 @@ class ParticipantFacadeTest {
     @Test
     @DisplayName("참가자 조회 실패 시 예외 발생")
     void getParticipant_fail() {
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
         when(participantService.getParticipant(user, festival)).thenReturn(null);
 
         assertThatThrownBy(() -> participantFacade.getParticipant(1L, 1L))
                 .isInstanceOf(FestimateException.class)
                 .hasMessageContaining(ResponseError.PARTICIPANT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("같은 유저가 같은 페스티벌에 중복 참가하려고 하면 예외가 발생해야 한다")
+    void createParticipant_duplicate_fail() {
+        // given
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
+        when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
+        // 이미 참가자가 존재한다고 설정
+        when(participantService.getParticipant(user, festival)).thenReturn(participant);
+
+        // createParticipant 호출 시 예외를 직접 발생시키도록 설정
+        when(participantService.createParticipant(any(), any(), any()))
+                .thenThrow(new FestimateException(ResponseError.PARTICIPANT_ALREADY_EXISTS));
+
+        // when & then
+        assertThatThrownBy(() -> participantFacade.createParticipant(1L, 1L,
+                new ProfileRequest(TypeResult.HEALING, "자기소개", "메시지")))
+                .isInstanceOf(FestimateException.class)
+                .hasMessageContaining(ResponseError.PARTICIPANT_ALREADY_EXISTS.getMessage());
     }
 }

--- a/src/test/java/org/festimate/team/api/facade/PointFacadeTest.java
+++ b/src/test/java/org/festimate/team/api/facade/PointFacadeTest.java
@@ -61,7 +61,7 @@ class PointFacadeTest {
     void getMyPointHistory_success() {
         // given
         when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
-        when(userService.getUserById(2L)).thenReturn(participantUser);
+        when(userService.getUserByIdOrThrow(2L)).thenReturn(participantUser);
         when(participantService.getParticipant(participantUser, festival)).thenReturn(participant);
 
         PointHistoryResponse dummyResponse = PointHistoryResponse.from(5, List.of());
@@ -78,7 +78,7 @@ class PointFacadeTest {
     @DisplayName("다른 참가자의 포인트 내역 조회 성공 (호스트 권한)")
     void getParticipantPointHistory_success() {
         // given
-        when(userService.getUserById(1L)).thenReturn(host);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(host);
         when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
         when(festivalService.isHost(host, festival)).thenReturn(true);
         when(participantService.getParticipantById(200L)).thenReturn(participant);
@@ -99,7 +99,7 @@ class PointFacadeTest {
         // given
         RechargePointRequest request = new RechargePointRequest(200L, 5);
 
-        when(userService.getUserById(1L)).thenReturn(host);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(host);
         when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
         when(festivalService.isHost(host, festival)).thenReturn(true);
         when(participantService.getParticipantById(200L)).thenReturn(participant);
@@ -117,7 +117,7 @@ class PointFacadeTest {
         User attacker = MockFactory.mockUser("악당", Gender.MAN, 999L);
         RechargePointRequest request = new RechargePointRequest(200L, 5);
 
-        when(userService.getUserById(999L)).thenReturn(attacker);
+        when(userService.getUserByIdOrThrow(999L)).thenReturn(attacker);
         when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
         when(festivalService.isHost(attacker, festival)).thenReturn(false);
 
@@ -135,7 +135,7 @@ class PointFacadeTest {
 
         RechargePointRequest request = new RechargePointRequest(300L, 5);
 
-        when(userService.getUserById(1L)).thenReturn(host);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(host);
         when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
         when(festivalService.isHost(host, festival)).thenReturn(true);
         when(participantService.getParticipantById(300L)).thenReturn(otherParticipant);

--- a/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
@@ -83,7 +83,7 @@ public class MatchingServiceImplTest {
                 .build();
 
         when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
-        when(userService.getUserById(1L)).thenReturn(user);
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
         when(participantService.getParticipant(user, festival)).thenReturn(participant);
         when(matchingRepository.findAllMatchingsByApplicantParticipant(participant))
                 .thenReturn(List.of(matching2, matching1));


### PR DESCRIPTION
## 📌 PR 제목
[fix] #103 같은 유저의 중복 참가 방지 및 참가자 조회 로직 리팩토링

## 📌 PR 내용
- 같은 유저가 동일한 페스티벌에 여러 번 참가할 수 있는 문제를 해결했습니다.
- entryFestival에서 중복된 유저·페스티벌 조회 로직을 제거하고 getParticipant()로 일원화했습니다.

## 🛠 작업 내용
- [x] 중복 참가자 생성 방지 (PARTICIPANT_ALREADY_EXISTS 예외 처리 추가)
- [x] entryFestival() 내부 로직 리팩토링
- [x] 중복 참가 예외 테스트 코드 추가

## 🔍 관련 이슈
Closes #103 

## 📸 스크린샷 (Optional)
<img width="641" alt="image" src="https://github.com/user-attachments/assets/00425b35-cef8-424d-849c-eba6877959c7" />

## 📚 레퍼런스 (Optional)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved user validation across the app by ensuring that operations now throw an error if a user is not found, rather than proceeding silently.

- **Tests**
  - Updated tests to reflect stricter user validation.
  - Added a new test to confirm that duplicate participant creation is properly blocked with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->