### PR TITLE
[refactor] #105 RESTful URI 구조로 통일 및 Admin API 분리

### DIFF
--- a/src/main/java/org/festimate/team/api/admin/AdminController.java
+++ b/src/main/java/org/festimate/team/api/admin/AdminController.java
@@ -1,0 +1,89 @@
+package org.festimate.team.api.admin;
+
+import lombok.RequiredArgsConstructor;
+import org.festimate.team.api.admin.dto.*;
+import org.festimate.team.api.facade.FestivalFacade;
+import org.festimate.team.api.facade.ParticipantFacade;
+import org.festimate.team.api.facade.PointFacade;
+import org.festimate.team.api.point.dto.PointHistoryResponse;
+import org.festimate.team.api.point.dto.RechargePointRequest;
+import org.festimate.team.global.response.ApiResponse;
+import org.festimate.team.global.response.ResponseBuilder;
+import org.festimate.team.infra.jwt.JwtService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/admin/festivals")
+@RequiredArgsConstructor
+public class AdminController {
+    private final JwtService jwtService;
+    private final FestivalFacade festivalFacade;
+    private final ParticipantFacade participantFacade;
+    private final PointFacade pointFacade;
+
+    @PostMapping()
+    public ResponseEntity<ApiResponse<FestivalResponse>> createFestival(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestBody FestivalRequest request
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        FestivalResponse response = festivalFacade.createFestival(userId, request);
+        return ResponseBuilder.created(response);
+    }
+
+    @GetMapping()
+    public ResponseEntity<ApiResponse<List<AdminFestivalResponse>>> getAllFestivals(
+            @RequestHeader("Authorization") String accessToken
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        List<AdminFestivalResponse> response = festivalFacade.getAllFestivals(userId);
+        return ResponseBuilder.ok(response);
+    }
+
+    @GetMapping("/{festivalId}")
+    public ResponseEntity<ApiResponse<AdminFestivalDetailResponse>> getFestivalDetail(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable Long festivalId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        AdminFestivalDetailResponse response = festivalFacade.getFestivalDetail(userId, festivalId);
+        return ResponseBuilder.ok(response);
+    }
+
+    @GetMapping("/{festivalId}/participants/search")
+    public ResponseEntity<ApiResponse<List<SearchParticipantResponse>>> getParticipantByNickname(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @RequestParam("nickname") String nickname
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+
+        List<SearchParticipantResponse> response = participantFacade.getParticipantByNickname(userId, festivalId, nickname);
+        return ResponseBuilder.ok(response);
+    }
+
+    @PostMapping("/{festivalId}/points")
+    public ResponseEntity<ApiResponse<Void>> rechargePoints(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @RequestBody RechargePointRequest request
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        pointFacade.rechargePoints(userId, festivalId, request);
+        return ResponseBuilder.created(null);
+    }
+
+    @GetMapping("/{festivalId}/participants/{participantId}/points")
+    public ResponseEntity<ApiResponse<PointHistoryResponse>> getParticipantPointHistory(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @PathVariable("participantId") Long participantId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        PointHistoryResponse response = pointFacade.getParticipantPointHistory(userId, festivalId, participantId);
+        return ResponseBuilder.ok(response);
+    }
+}

--- a/src/main/java/org/festimate/team/api/admin/AdminController.java
+++ b/src/main/java/org/festimate/team/api/admin/AdminController.java
@@ -73,7 +73,7 @@ public class AdminController {
     ) {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
         pointFacade.rechargePoints(userId, festivalId, request);
-        return ResponseBuilder.created(null);
+        return ResponseBuilder.ok(null);
     }
 
     @GetMapping("/{festivalId}/participants/{participantId}/points")

--- a/src/main/java/org/festimate/team/api/admin/dto/AdminFestivalDetailResponse.java
+++ b/src/main/java/org/festimate/team/api/admin/dto/AdminFestivalDetailResponse.java
@@ -1,4 +1,4 @@
-package org.festimate.team.api.festival.dto;
+package org.festimate.team.api.admin.dto;
 
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.entity.FestivalStatus;

--- a/src/main/java/org/festimate/team/api/admin/dto/AdminFestivalResponse.java
+++ b/src/main/java/org/festimate/team/api/admin/dto/AdminFestivalResponse.java
@@ -1,4 +1,4 @@
-package org.festimate.team.api.festival.dto;
+package org.festimate.team.api.admin.dto;
 
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.entity.FestivalStatus;

--- a/src/main/java/org/festimate/team/api/admin/dto/FestivalRequest.java
+++ b/src/main/java/org/festimate/team/api/admin/dto/FestivalRequest.java
@@ -1,4 +1,4 @@
-package org.festimate.team.api.festival.dto;
+package org.festimate.team.api.admin.dto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/org/festimate/team/api/admin/dto/FestivalResponse.java
+++ b/src/main/java/org/festimate/team/api/admin/dto/FestivalResponse.java
@@ -1,4 +1,4 @@
-package org.festimate.team.api.festival.dto;
+package org.festimate.team.api.admin.dto;
 
 public record FestivalResponse(
         Long festivalId,

--- a/src/main/java/org/festimate/team/api/admin/dto/SearchParticipantResponse.java
+++ b/src/main/java/org/festimate/team/api/admin/dto/SearchParticipantResponse.java
@@ -1,4 +1,4 @@
-package org.festimate.team.api.participant.dto;
+package org.festimate.team.api.admin.dto;
 
 import org.festimate.team.domain.participant.entity.Participant;
 

--- a/src/main/java/org/festimate/team/api/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/FestivalFacade.java
@@ -1,7 +1,13 @@
 package org.festimate.team.api.facade;
 
 import lombok.RequiredArgsConstructor;
-import org.festimate.team.api.festival.dto.*;
+import org.festimate.team.api.admin.dto.AdminFestivalDetailResponse;
+import org.festimate.team.api.admin.dto.AdminFestivalResponse;
+import org.festimate.team.api.admin.dto.FestivalRequest;
+import org.festimate.team.api.admin.dto.FestivalResponse;
+import org.festimate.team.api.festival.dto.FestivalInfoResponse;
+import org.festimate.team.api.festival.dto.FestivalVerifyRequest;
+import org.festimate.team.api.festival.dto.FestivalVerifyResponse;
 import org.festimate.team.api.user.dto.UserFestivalResponse;
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.service.FestivalService;

--- a/src/main/java/org/festimate/team/api/facade/ParticipantFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/ParticipantFacade.java
@@ -1,6 +1,7 @@
 package org.festimate.team.api.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.festimate.team.api.admin.dto.SearchParticipantResponse;
 import org.festimate.team.api.participant.dto.*;
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.service.FestivalService;

--- a/src/main/java/org/festimate/team/api/festival/FestivalController.java
+++ b/src/main/java/org/festimate/team/api/festival/FestivalController.java
@@ -9,8 +9,6 @@ import org.festimate.team.infra.jwt.JwtService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/v1/festivals")
 @RequiredArgsConstructor
@@ -18,7 +16,7 @@ public class FestivalController {
     private final JwtService jwtService;
     private final FestivalFacade festivalFacade;
 
-    @PostMapping("/verify-code")
+    @PostMapping("/verify")
     public ResponseEntity<ApiResponse<FestivalVerifyResponse>> verifyFestival(
             @RequestHeader("Authorization") String accessToken,
             @RequestBody FestivalVerifyRequest request
@@ -35,35 +33,6 @@ public class FestivalController {
     ) {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
         FestivalInfoResponse response = festivalFacade.getFestivalInfo(userId, festivalId);
-        return ResponseBuilder.ok(response);
-    }
-
-    @PostMapping("/admin/festival")
-    public ResponseEntity<ApiResponse<FestivalResponse>> createFestival(
-            @RequestHeader("Authorization") String accessToken,
-            @RequestBody FestivalRequest request
-    ) {
-        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
-        FestivalResponse response = festivalFacade.createFestival(userId, request);
-        return ResponseBuilder.created(response);
-    }
-
-    @GetMapping("/admin/festivals")
-    public ResponseEntity<ApiResponse<List<AdminFestivalResponse>>> getAllFestivals(
-            @RequestHeader("Authorization") String accessToken
-    ) {
-        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
-        List<AdminFestivalResponse> response = festivalFacade.getAllFestivals(userId);
-        return ResponseBuilder.ok(response);
-    }
-
-    @GetMapping("/admin/festivals/{festivalId}")
-    public ResponseEntity<ApiResponse<AdminFestivalDetailResponse>> getFestivalDetail(
-            @RequestHeader("Authorization") String accessToken,
-            @PathVariable Long festivalId
-    ) {
-        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
-        AdminFestivalDetailResponse response = festivalFacade.getFestivalDetail(userId, festivalId);
         return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/api/participant/ParticipantController.java
+++ b/src/main/java/org/festimate/team/api/participant/ParticipantController.java
@@ -10,10 +10,8 @@ import org.festimate.team.infra.jwt.JwtService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
-@RequestMapping("/v1")
+@RequestMapping("/v1/festivals")
 @RequiredArgsConstructor
 public class ParticipantController {
 
@@ -21,18 +19,18 @@ public class ParticipantController {
     private final ParticipantService participantService;
     private final ParticipantFacade participantFacade;
 
-    @PostMapping("/participants/type")
+    @PostMapping("/{festivalId}/participants/type")
     public ResponseEntity<ApiResponse<TypeResponse>> getFestivalType(
             @RequestHeader("Authorization") String accessToken,
+            @PathVariable Long festivalId,
             @RequestBody TypeRequest request
     ) {
         jwtService.parseTokenAndGetUserId(accessToken);
-
         TypeResponse response = participantService.getTypeResult(request);
         return ResponseBuilder.ok(response);
     }
 
-    @PostMapping("/festivals/{festivalId}/entry")
+    @GetMapping("/{festivalId}/participants/me")
     public ResponseEntity<ApiResponse<EntryResponse>> entryFestival(
             @RequestHeader("Authorization") String accessToken,
             @PathVariable("festivalId") Long festivalId
@@ -43,7 +41,7 @@ public class ParticipantController {
         return ResponseBuilder.ok(response);
     }
 
-    @PostMapping("/festivals/{festivalId}/participants")
+    @PostMapping("/{festivalId}/participants")
     public ResponseEntity<ApiResponse<EntryResponse>> createParticipant(
             @RequestHeader("Authorization") String accessToken,
             @PathVariable("festivalId") Long festivalId,
@@ -54,7 +52,7 @@ public class ParticipantController {
         return ResponseBuilder.created(response);
     }
 
-    @GetMapping("/festivals/{festivalId}/me")
+    @GetMapping("/{festivalId}/participants/me/profile")
     public ResponseEntity<ApiResponse<ProfileResponse>> getMyProfile(
             @RequestHeader("Authorization") String accessToken,
             @PathVariable("festivalId") Long festivalId
@@ -64,7 +62,7 @@ public class ParticipantController {
         return ResponseBuilder.ok(response);
     }
 
-    @GetMapping("/festivals/{festivalId}/me/summary")
+    @GetMapping("/{festivalId}/participants/me/summary")
     public ResponseEntity<ApiResponse<MainUserInfoResponse>> getParticipantAndPoint(
             @RequestHeader("Authorization") String accessToken,
             @PathVariable("festivalId") Long festivalId
@@ -75,7 +73,7 @@ public class ParticipantController {
         return ResponseBuilder.ok(response);
     }
 
-    @GetMapping("/festivals/{festivalId}/me/type")
+    @GetMapping("/{festivalId}/participants/me/type")
     public ResponseEntity<ApiResponse<DetailProfileResponse>> getParticipantType(
             @RequestHeader("Authorization") String accessToken,
             @PathVariable("festivalId") Long festivalId
@@ -86,7 +84,7 @@ public class ParticipantController {
         return ResponseBuilder.ok(response);
     }
 
-    @PatchMapping("/festivals/{festivalId}/me/message")
+    @PatchMapping("/{festivalId}/participants/me/message")
     public ResponseEntity<ApiResponse<Void>> modifyMyMessage(
             @RequestHeader("Authorization") String accessToken,
             @PathVariable("festivalId") Long festivalId,
@@ -96,17 +94,5 @@ public class ParticipantController {
         participantFacade.modifyMessage(userId, festivalId, request);
 
         return ResponseBuilder.created(null);
-    }
-
-    @GetMapping("/admin/festivals/{festivalId}/participants/search")
-    public ResponseEntity<ApiResponse<List<SearchParticipantResponse>>> getParticipantByNickname(
-            @RequestHeader("Authorization") String accessToken,
-            @PathVariable("festivalId") Long festivalId,
-            @RequestParam("nickname") String nickname
-    ) {
-        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
-
-        List<SearchParticipantResponse> response = participantFacade.getParticipantByNickname(userId, festivalId, nickname);
-        return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/api/point/PointController.java
+++ b/src/main/java/org/festimate/team/api/point/PointController.java
@@ -3,7 +3,6 @@ package org.festimate.team.api.point;
 import lombok.RequiredArgsConstructor;
 import org.festimate.team.api.facade.PointFacade;
 import org.festimate.team.api.point.dto.PointHistoryResponse;
-import org.festimate.team.api.point.dto.RechargePointRequest;
 import org.festimate.team.global.response.ApiResponse;
 import org.festimate.team.global.response.ResponseBuilder;
 import org.festimate.team.infra.jwt.JwtService;
@@ -18,35 +17,13 @@ public class PointController {
     private final JwtService jwtService;
     private final PointFacade pointFacade;
 
-    @GetMapping("/festivals/{festivalId}/me/points")
+    @GetMapping("/festivals/{festivalId}/participants/me/points")
     public ResponseEntity<ApiResponse<PointHistoryResponse>> getMyPointHistory(
             @RequestHeader("Authorization") String accessToken,
             @PathVariable("festivalId") Long festivalId
     ) {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
         PointHistoryResponse response = pointFacade.getMyPointHistory(userId, festivalId);
-        return ResponseBuilder.ok(response);
-    }
-
-    @PostMapping("/admin/festival/{festivalId}/points")
-    public ResponseEntity<ApiResponse<Void>> rechargePoints(
-            @RequestHeader("Authorization") String accessToken,
-            @PathVariable("festivalId") Long festivalId,
-            @RequestBody RechargePointRequest request
-    ) {
-        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
-        pointFacade.rechargePoints(userId, festivalId, request);
-        return ResponseBuilder.created(null);
-    }
-
-    @GetMapping("/admin/festivals/{festivalId}/participants/{participantId}/points")
-    public ResponseEntity<ApiResponse<PointHistoryResponse>> getParticipantPointHistory(
-            @RequestHeader("Authorization") String accessToken,
-            @PathVariable("festivalId") Long festivalId,
-            @PathVariable("participantId") Long participantId
-    ) {
-        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
-        PointHistoryResponse response = pointFacade.getParticipantPointHistory(userId, festivalId, participantId);
         return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/domain/festival/service/FestivalService.java
+++ b/src/main/java/org/festimate/team/domain/festival/service/FestivalService.java
@@ -1,6 +1,6 @@
 package org.festimate.team.domain.festival.service;
 
-import org.festimate.team.api.festival.dto.FestivalRequest;
+import org.festimate.team.api.admin.dto.FestivalRequest;
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.user.entity.User;
 

--- a/src/main/java/org/festimate/team/domain/festival/service/impl/FestivalServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/festival/service/impl/FestivalServiceImpl.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.festimate.team.global.response.ResponseError;
 import org.festimate.team.global.exception.FestimateException;
-import org.festimate.team.api.festival.dto.FestivalRequest;
+import org.festimate.team.api.admin.dto.FestivalRequest;
 import org.festimate.team.domain.festival.entity.Category;
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.repository.FestivalRepository;

--- a/src/test/java/org/festimate/team/api/facade/FestivalFacadeTest.java
+++ b/src/test/java/org/festimate/team/api/facade/FestivalFacadeTest.java
@@ -1,6 +1,6 @@
 package org.festimate.team.api.facade;
 
-import org.festimate.team.api.festival.dto.FestivalRequest;
+import org.festimate.team.api.admin.dto.FestivalRequest;
 import org.festimate.team.api.festival.dto.FestivalVerifyRequest;
 import org.festimate.team.common.mock.MockFactory;
 import org.festimate.team.domain.festival.entity.Festival;


### PR DESCRIPTION
## 📌 PR 제목
[refactor] #105 RESTful URI 구조로 통일 및 Admin API 분리

## 📌 PR 내용
- 전체 컨트롤러의 URI를 RESTful하게 통일하고, admin 전용 API를 별도 컨트롤러로 분리했습니다.

## 🛠 작업 내용
- [x]  /{festivalId}/participants/me 형태로 URI 구조 일관성 확보
- [x] Admin 전용 API를 AdminController로 분리
- [x] PointController 내 URI 일관성 확보
- [x] 중복되는 URI 패턴 정리 및 명확한 리소스 명명 적용

## 🔍 관련 이슈
Closes #105 

## 📸 스크린샷 (Optional)
<img width="823" alt="image" src="https://github.com/user-attachments/assets/4fb6c6d6-65a7-488d-b728-46927e43a18c" />

## 📚 레퍼런스 (Optional)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new admin endpoints for managing festivals, participants, and points, including creating festivals, retrieving festival details, searching participants by nickname, recharging points, and viewing participant point history.

- **Refactor**
  - Updated and reorganized endpoint paths for participant and point operations to provide a more consistent and hierarchical URL structure.
  - Moved several data transfer objects to new package locations for improved organization.

- **Bug Fixes**
  - Removed admin-related endpoints from non-admin controllers to prevent unauthorized access and improve endpoint clarity.

- **Style**
  - Updated endpoint naming for verification to enhance clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->