### PR TITLE
[fix] #107 참가자 조회 시 null 반환 제거 및 예외 처리 방식 통일

### DIFF
--- a/src/main/java/org/festimate/team/api/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/FestivalFacade.java
@@ -36,14 +36,13 @@ public class FestivalFacade {
     public FestivalInfoResponse getFestivalInfo(Long userId, Long festivalId) {
         User user = userService.getUserByIdOrThrow(userId);
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
-        participantService.validateParticipation(user, festival);
+        participantService.getParticipantOrThrow(user, festival);
         return FestivalInfoResponse.of(festival);
     }
 
     @Transactional
     public FestivalResponse createFestival(Long userId, FestivalRequest request) {
         User host = userService.getUserByIdOrThrow(userId);
-
         festivalService.validateCreateFestival(request);
 
         Festival festival = festivalService.createFestival(host, request);

--- a/src/main/java/org/festimate/team/api/facade/ParticipantFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/ParticipantFacade.java
@@ -77,11 +77,7 @@ public class ParticipantFacade {
     public Participant getParticipant(Long userId, Long festivalId) {
         User user = userService.getUserByIdOrThrow(userId);
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
-        Participant participant = participantService.getParticipant(user, festival);
-        if (participant == null) {
-            throw new FestimateException(ResponseError.PARTICIPANT_NOT_FOUND);
-        }
-        return participant;
+        return participantService.getParticipantOrThrow(user, festival);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/festimate/team/api/facade/PointFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/PointFacade.java
@@ -26,8 +26,9 @@ public class PointFacade {
 
     @Transactional(readOnly = true)
     public PointHistoryResponse getMyPointHistory(Long userId, Long festivalId) {
+        User user = userService.getUserByIdOrThrow(userId);
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
-        Participant participant = getExistingParticipantOrThrow(userId, festival);
+        Participant participant = participantService.getParticipantOrThrow(user, festival);
         return pointService.getPointHistory(participant);
     }
 
@@ -51,15 +52,6 @@ public class PointFacade {
             throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
         }
         pointService.rechargePoint(participant, request.point());
-    }
-
-    private Participant getExistingParticipantOrThrow(Long userId, Festival festival) {
-        User user = userService.getUserByIdOrThrow(userId);
-        Participant participant = participantService.getParticipant(user, festival);
-        if (participant == null) {
-            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
-        }
-        return participant;
     }
 
     private void isHost(User user, Festival festival) {

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -17,8 +17,6 @@ import org.festimate.team.domain.participant.service.ParticipantService;
 import org.festimate.team.domain.point.service.PointService;
 import org.festimate.team.domain.user.entity.Gender;
 import org.festimate.team.domain.user.service.UserService;
-import org.festimate.team.global.exception.FestimateException;
-import org.festimate.team.global.response.ResponseError;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,7 +40,9 @@ public class MatchingServiceImpl implements MatchingService {
     @Transactional
     public MatchingStatusResponse createMatching(Long userId, Long festivalId) {
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
-        Participant participant = getExistingParticipantOrThrow(userId, festival);
+        Participant participant = participantService.getParticipantOrThrow(
+                userService.getUserByIdOrThrow(userId), festival
+        );
 
         isMatchingDateValid(LocalDateTime.now(), festival.getMatchingStartAt());
 
@@ -58,20 +58,12 @@ public class MatchingServiceImpl implements MatchingService {
     @Override
     public MatchingListResponse getMatchingList(Long userId, Long festivalId) {
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
-        Participant participant = getExistingParticipantOrThrow(userId, festival);
+        Participant participant = participantService.getParticipantOrThrow(
+                userService.getUserByIdOrThrow(userId), festival
+        );
 
         List<MatchingInfo> matchings = getMatchingListByParticipant(participant);
         return MatchingListResponse.from(matchings);
-    }
-
-    private Participant getExistingParticipantOrThrow(Long userId, Festival festival) {
-        Participant participant = participantService.getParticipant(
-                userService.getUserByIdOrThrow(userId), festival
-        );
-        if (participant == null) {
-            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
-        }
-        return participant;
     }
 
     @Transactional

--- a/src/main/java/org/festimate/team/domain/participant/service/ParticipantService.java
+++ b/src/main/java/org/festimate/team/domain/participant/service/ParticipantService.java
@@ -15,9 +15,9 @@ public interface ParticipantService {
     @Transactional
     Participant createParticipant(User user, Festival festival, ProfileRequest request);
 
-    Participant getParticipant(User user, Festival festival);
+    Participant getParticipantOrThrow(User user, Festival festival);
 
-    void validateParticipation(User user, Festival festival);
+    Participant getParticipant(User user, Festival festival);
 
     Participant getParticipantById(Long participantId);
 

--- a/src/main/java/org/festimate/team/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -46,10 +47,9 @@ public class ParticipantServiceImpl implements ParticipantService {
     }
 
     @Override
-    public void validateParticipation(User user, Festival festival) {
-        if (getParticipant(user, festival) == null) {
-            throw new FestimateException(ResponseError.PARTICIPANT_NOT_FOUND);
-        }
+    public Participant getParticipantOrThrow(User user, Festival festival) {
+        return Optional.ofNullable(participantRepository.getParticipantByUserAndFestival(user, festival))
+                .orElseThrow(() -> new FestimateException(ResponseError.PARTICIPANT_NOT_FOUND));
     }
 
     @Override

--- a/src/test/java/org/festimate/team/api/facade/PointFacadeTest.java
+++ b/src/test/java/org/festimate/team/api/facade/PointFacadeTest.java
@@ -62,7 +62,7 @@ class PointFacadeTest {
         // given
         when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
         when(userService.getUserByIdOrThrow(2L)).thenReturn(participantUser);
-        when(participantService.getParticipant(participantUser, festival)).thenReturn(participant);
+        when(participantService.getParticipantOrThrow(participantUser, festival)).thenReturn(participant);
 
         PointHistoryResponse dummyResponse = PointHistoryResponse.from(5, List.of());
         when(pointService.getPointHistory(participant)).thenReturn(dummyResponse);

--- a/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
@@ -84,7 +84,7 @@ public class MatchingServiceImplTest {
 
         when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
         when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
-        when(participantService.getParticipant(user, festival)).thenReturn(participant);
+        when(participantService.getParticipantOrThrow(user, festival)).thenReturn(participant);
         when(matchingRepository.findAllMatchingsByApplicantParticipant(participant))
                 .thenReturn(List.of(matching2, matching1));
 


### PR DESCRIPTION
## 📌 PR 제목
[fix] #107 참가자 조회 시 null 반환 제거 및 예외 처리 방식 통일

## 📌 PR 내용
- 참가자 조회 시 null 반환을 제거하고, 예외를 던지는 방식(getParticipantOrThrow)으로 전면 통일했습니다.
- 중복 참가자 확인 로직(createParticipant)에서는 유일하게 null 허용 방식(getParticipant)을 유지합니다.
- 이에 따라 Facade 및 테스트 코드 전반에서 불필요한 null 체크를 제거했습니다.

## 🛠 작업 내용
- [x] ParticipantService에 getParticipantOrThrow 메서드 명시적으로 분리
- [x]  ParticipantFacade, FestivalFacade, PointFacade의 조회 로직 예외 방식으로 일원화
- [x]  테스트 코드 내 mock 및 예외 처리 방식 수정
- [x]  중복 참가자 확인은 getParticipant로 유지

## 🔍 관련 이슈
Closes #107 

## 📸 스크린샷 (Optional)

## 📚 레퍼런스 (Optional)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling when retrieving participant information, ensuring clearer feedback if a participant is not found.
- **Refactor**
	- Streamlined internal logic for participant validation and retrieval, reducing redundant checks and simplifying control flow.
- **Tests**
	- Updated tests to reflect new participant retrieval and error handling methods, ensuring continued reliability and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->