### PR TITLE
[feat] #110 매칭 상세조회 API 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/api/matching/MatchingController.java
+++ b/src/main/java/org/festimate/team/api/matching/MatchingController.java
@@ -1,6 +1,7 @@
 package org.festimate.team.api.matching;
 
 import lombok.RequiredArgsConstructor;
+import org.festimate.team.api.matching.dto.MatchingDetailInfo;
 import org.festimate.team.api.matching.dto.MatchingListResponse;
 import org.festimate.team.api.matching.dto.MatchingStatusResponse;
 import org.festimate.team.domain.matching.service.MatchingService;
@@ -36,6 +37,18 @@ public class MatchingController {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
 
         MatchingListResponse response = matchingService.getMatchingList(userId, festivalId);
+        return ResponseBuilder.ok(response);
+    }
+
+    @GetMapping("/{festivalId}/matchings/{matchingId}")
+    public ResponseEntity<ApiResponse<MatchingDetailInfo>> getMatchingDetail(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @PathVariable("matchingId") Long matchingId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+
+        MatchingDetailInfo response = matchingService.getMatchingDetail(userId, festivalId, matchingId);
         return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/api/matching/dto/MatchingDetailInfo.java
+++ b/src/main/java/org/festimate/team/api/matching/dto/MatchingDetailInfo.java
@@ -1,0 +1,33 @@
+package org.festimate.team.api.matching.dto;
+
+import org.festimate.team.domain.matching.entity.Matching;
+import org.festimate.team.domain.participant.entity.Participant;
+import org.festimate.team.domain.participant.entity.TypeResult;
+import org.festimate.team.domain.user.entity.AppearanceType;
+import org.festimate.team.domain.user.entity.Gender;
+import org.festimate.team.domain.user.entity.Mbti;
+
+public record MatchingDetailInfo(
+        String nickname,
+        Gender gender,
+        Integer birthYear,
+        Mbti mbti,
+        AppearanceType appearance,
+        String introduction,
+        String message,
+        TypeResult typeResult
+) {
+    public static MatchingDetailInfo from(Matching matching) {
+        Participant participant = matching.getTargetParticipant();
+        return new MatchingDetailInfo(
+                participant.getUser().getNickname(),
+                participant.getUser().getGender(),
+                participant.getUser().getBirthYear(),
+                participant.getUser().getMbti(),
+                participant.getUser().getAppearanceType(),
+                participant.getIntroduction(),
+                participant.getMessage(),
+                participant.getTypeResult()
+        );
+    }
+}

--- a/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
@@ -75,5 +75,6 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             """)
     List<Matching> findAllMatchingsByApplicantParticipant(Participant participant);
 
+    Matching findByMatchingId(Long matchingId);
 }
 

--- a/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
@@ -75,6 +75,6 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             """)
     List<Matching> findAllMatchingsByApplicantParticipant(Participant participant);
 
-    Matching findByMatchingId(Long matchingId);
+    Optional<Matching> findByMatchingId(Long matchingId);
 }
 

--- a/src/main/java/org/festimate/team/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/MatchingService.java
@@ -1,5 +1,6 @@
 package org.festimate.team.domain.matching.service;
 
+import org.festimate.team.api.matching.dto.MatchingDetailInfo;
 import org.festimate.team.api.matching.dto.MatchingListResponse;
 import org.festimate.team.api.matching.dto.MatchingStatusResponse;
 import org.festimate.team.domain.participant.entity.Participant;
@@ -10,6 +11,8 @@ public interface MatchingService {
     MatchingStatusResponse createMatching(Long userId, Long festivalId);
 
     MatchingListResponse getMatchingList(Long userId, Long festivalId);
+
+    MatchingDetailInfo getMatchingDetail(Long userId, Long festivalId, Long matchingId);
 
     Optional<Participant> findBestCandidateByPriority(long festivalId, Participant participant);
 

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -74,7 +74,8 @@ public class MatchingServiceImpl implements MatchingService {
     public MatchingDetailInfo getMatchingDetail(Long userId, Long festivalId, Long matchingId) {
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
         participantService.getParticipantOrThrow(userService.getUserByIdOrThrow(userId), festival);
-        Matching matching = matchingRepository.findByMatchingId(matchingId);
+        Matching matching = Optional.ofNullable(matchingRepository.findByMatchingId(matchingId))
+                .orElseThrow(() -> new FestimateException(ResponseError.TARGET_NOT_FOUND));
         if (!matching.getFestival().getFestivalId().equals(festivalId)) {
             throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
         }

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -2,6 +2,7 @@ package org.festimate.team.domain.matching.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.api.matching.dto.MatchingDetailInfo;
 import org.festimate.team.api.matching.dto.MatchingInfo;
 import org.festimate.team.api.matching.dto.MatchingListResponse;
 import org.festimate.team.api.matching.dto.MatchingStatusResponse;
@@ -17,6 +18,8 @@ import org.festimate.team.domain.participant.service.ParticipantService;
 import org.festimate.team.domain.point.service.PointService;
 import org.festimate.team.domain.user.entity.Gender;
 import org.festimate.team.domain.user.service.UserService;
+import org.festimate.team.global.exception.FestimateException;
+import org.festimate.team.global.response.ResponseError;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,6 +67,18 @@ public class MatchingServiceImpl implements MatchingService {
 
         List<MatchingInfo> matchings = getMatchingListByParticipant(participant);
         return MatchingListResponse.from(matchings);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public MatchingDetailInfo getMatchingDetail(Long userId, Long festivalId, Long matchingId) {
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        participantService.getParticipantOrThrow(userService.getUserByIdOrThrow(userId), festival);
+        Matching matching = matchingRepository.findByMatchingId(matchingId);
+        if (!matching.getFestival().getFestivalId().equals(festivalId)) {
+            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
+        }
+        return MatchingDetailInfo.from(matching);
     }
 
     @Transactional

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -74,7 +74,7 @@ public class MatchingServiceImpl implements MatchingService {
     public MatchingDetailInfo getMatchingDetail(Long userId, Long festivalId, Long matchingId) {
         Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
         participantService.getParticipantOrThrow(userService.getUserByIdOrThrow(userId), festival);
-        Matching matching = Optional.ofNullable(matchingRepository.findByMatchingId(matchingId))
+        Matching matching = matchingRepository.findByMatchingId(matchingId)
                 .orElseThrow(() -> new FestimateException(ResponseError.TARGET_NOT_FOUND));
         if (!matching.getFestival().getFestivalId().equals(festivalId)) {
             throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);

--- a/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.festimate.team.common.mock.MockFactory.*;
 import static org.mockito.Mockito.when;
 
-public class MatchingServiceImplTest {
+class MatchingServiceImplTest {
     @Mock
     private MatchingRepository matchingRepository;
 
@@ -263,7 +263,7 @@ public class MatchingServiceImplTest {
         when(userService.getUserByIdOrThrow(user.getUserId())).thenReturn(user);
         when(festivalService.getFestivalByIdOrThrow(requestedFestival.getFestivalId())).thenReturn(requestedFestival);
         when(participantService.getParticipantOrThrow(user, requestedFestival)).thenReturn(participant);
-        when(matchingRepository.findByMatchingId(1L)).thenReturn(mismatchedMatching);
+        when(matchingRepository.findByMatchingId(1L)).thenReturn(Optional.of(mismatchedMatching));
 
         // when & then
         assertThatThrownBy(() -> matchingService.getMatchingDetail(user.getUserId(), requestedFestival.getFestivalId(), 1L))


### PR DESCRIPTION
## 📌 PR 제목
[feat] #110 매칭 상세조회 API 기능 구현

## 📌 PR 내용
- 사용자가 본인의 매칭 내역 중 특정 매칭의 상세 정보를 조회할 수 있는 기능을 구현했습니다.
- 요청한 페스티벌 ID와 매칭이 실제로 속한 페스티벌이 일치하는지 검증하여 권한을 제한합니다.

## 🛠 작업 내용
- [x]  매칭 상세조회 API 엔드포인트 구현 (GET /v1/festivals/{festivalId}/matchings/{matchingId})
- [x] MatchingService에 getMatchingDetail() 메서드 추가 및 권한 검증 로직 구현
- [x] 매칭-페스티벌 불일치 시 예외 처리 (FORBIDDEN_RESOURCE)
- [x] MatchingDetailInfo 응답 DTO 구성
- [x] 관련 단위 테스트 작성

## 🔍 관련 이슈
Closes #110 

## 📸 스크린샷 (Optional)
가능하다면 작업한 내용을 보여주는 스크린샷을 첨부해주세요.

## 📚 레퍼런스 (Optional)
추가로 공유할 정보가 있다면 여기에 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new API endpoint to retrieve detailed information about a specific matching participant for a given festival.
  - Users can now view participant details such as nickname, gender, birth year, MBTI, appearance, introduction, message, and type result via the new endpoint.

- **Bug Fixes**
  - Improved error handling to prevent access to matching details if the matching does not belong to the requested festival.

- **Tests**
  - Added a test to ensure proper error handling when attempting to access a matching from an incorrect festival.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->