### PR TITLE
[refactor] #72 N+1 문제 해결을 위한 매칭 후보자 탐색 쿼리 최적화

### DIFF
--- a/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
     @Query("""

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -77,6 +77,9 @@ public class MatchingServiceImpl implements MatchingService {
         participantService.getParticipantOrThrow(userService.getUserByIdOrThrow(userId), festival);
         Matching matching = matchingRepository.findByMatchingId(matchingId)
                 .orElseThrow(() -> new FestimateException(ResponseError.TARGET_NOT_FOUND));
+        if (matching.getTargetParticipant() == null || matching.getTargetParticipant().getUser() == null) {
+            throw new FestimateException(ResponseError.TARGET_NOT_FOUND);
+        }
         if (!matching.getFestival().getFestivalId().equals(festivalId)) {
             throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
         }

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -17,6 +17,7 @@ import org.festimate.team.domain.participant.service.ParticipantService;
 import org.festimate.team.domain.point.service.PointService;
 import org.festimate.team.domain.user.entity.Gender;
 import org.festimate.team.domain.user.service.UserService;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -86,12 +87,14 @@ public class MatchingServiceImpl implements MatchingService {
         Gender myGender = participant.getUser().getGender();
 
         for (TypeResult priorityType : priorities) {
-            Optional<Participant> candidate = matchingRepository.findMatchingCandidate(
+            Optional<Participant> candidate = matchingRepository.findMatchingCandidates(
                     participant.getParticipantId(),
                     priorityType,
                     myGender,
-                    festivalId
-            );
+                    festivalId,
+                    PageRequest.of(0, 1)
+            ).stream().findFirst();
+
             if (candidate.isPresent()) {
                 return candidate;
             }

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -45,12 +45,12 @@ public class MatchingServiceImpl implements MatchingService {
         );
 
         isMatchingDateValid(LocalDateTime.now(), festival.getMatchingStartAt());
-
         pointService.usePoint(participant);
 
-        Optional<Participant> targetParticipantOptional = findBestCandidateByPriority(festivalId, participant);
+        Optional<Participant> targetOptional = findBestCandidateByPriority(festivalId, participant);
+        Participant target = targetOptional.orElse(null);
 
-        Matching matching = saveMatching(festival, targetParticipantOptional, participant);
+        Matching matching = saveMatching(festival, Optional.ofNullable(target), participant);
         return MatchingStatusResponse.of(matching.getStatus(), matching.getMatchingId());
     }
 

--- a/src/test/java/org/festimate/team/domain/festival/entity/FestivalTest.java
+++ b/src/test/java/org/festimate/team/domain/festival/entity/FestivalTest.java
@@ -1,7 +1,5 @@
 package org.festimate.team.domain.festival.entity;
 
-import org.festimate.team.domain.festival.entity.Festival;
-import org.festimate.team.domain.festival.entity.FestivalStatus;
 import org.festimate.team.domain.user.entity.Gender;
 import org.festimate.team.domain.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
@@ -13,7 +11,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.festimate.team.common.mock.MockFactory.mockFestival;
 import static org.festimate.team.common.mock.MockFactory.mockUser;
 
-public class FestivalTest {
+class FestivalTest {
 
     private final User mockHost = mockUser("호스트", Gender.MAN, 1L);
 

--- a/src/test/java/org/festimate/team/domain/festival/service/impl/FestivalServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/festival/service/impl/FestivalServiceImplTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.when;
 
-public class FestivalServiceImplTest {
+class FestivalServiceImplTest {
     @Mock
     private FestivalRepository festivalRepository;
 

--- a/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
@@ -19,10 +19,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -118,13 +120,10 @@ class MatchingServiceImplTest {
                 .festival(festival)
                 .build();
 
-        when(matchingRepository.findMatchingCandidate(
-                1L, TypeResult.PHOTO, Gender.MAN, 1L
-        )).thenReturn(Optional.of(target));
+        when(matchingRepository.findMatchingCandidates(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+                .thenReturn(List.of(target));
 
-        Optional<Participant> result = matchingService.findBestCandidateByPriority(
-                festival.getFestivalId(), applicant
-        );
+        var result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
 
         assertThat(result).isPresent();
         assertThat(result.get().getTypeResult()).isEqualTo(TypeResult.PHOTO);
@@ -145,8 +144,8 @@ class MatchingServiceImplTest {
         ReflectionTestUtils.setField(applicant, "participantId", 1L);
 
         // 1순위 PHOTO에 대상 없음
-        when(matchingRepository.findMatchingCandidate(1L, TypeResult.PHOTO, Gender.MAN, 1L))
-                .thenReturn(Optional.empty());
+        when(matchingRepository.findMatchingCandidates(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+                .thenReturn(Collections.emptyList());
 
         // 2순위 INFLUENCER에 대상 있음
         Participant secondPriorityCandidate = Participant.builder()
@@ -154,10 +153,11 @@ class MatchingServiceImplTest {
                 .typeResult(TypeResult.INFLUENCER)
                 .festival(festival)
                 .build();
-        when(matchingRepository.findMatchingCandidate(1L, TypeResult.INFLUENCER, Gender.MAN, 1L))
-                .thenReturn(Optional.of(secondPriorityCandidate));
 
-        Optional<Participant> result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
+        when(matchingRepository.findMatchingCandidates(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
+                .thenReturn(List.of(secondPriorityCandidate));
+
+        var result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
 
         assertThat(result).isPresent();
         assertThat(result.get().getTypeResult()).isEqualTo(TypeResult.INFLUENCER);
@@ -171,21 +171,21 @@ class MatchingServiceImplTest {
         User thirdPriorityUser = mockUser("3순위타겟", Gender.WOMAN, 2L);
         Festival festival = mockFestival(applicantUser, 1L, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
 
+        // 신청자
         Participant applicant = mockParticipant(applicantUser, festival, TypeResult.INFLUENCER, 1L);
-
-        // 1순위 PHOTO, 2순위 INFLUENCER 대상 없음
-        when(matchingRepository.findMatchingCandidate(applicant.getParticipantId(), TypeResult.PHOTO, Gender.MAN, festival.getFestivalId()))
-                .thenReturn(Optional.empty());
-        when(matchingRepository.findMatchingCandidate(applicant.getParticipantId(), TypeResult.INFLUENCER, Gender.MAN, festival.getFestivalId()))
-                .thenReturn(Optional.empty());
-
         // 3순위 NEWBIE에 대상 있음
         Participant thirdPriorityCandidate = mockParticipant(thirdPriorityUser, festival, TypeResult.NEWBIE, 2L);
 
-        when(matchingRepository.findMatchingCandidate(applicant.getParticipantId(), TypeResult.NEWBIE, Gender.MAN, festival.getFestivalId()))
-                .thenReturn(Optional.of(thirdPriorityCandidate));
+        // 1순위 PHOTO, 2순위 INFLUENCER 대상 없음
+        when(matchingRepository.findMatchingCandidates(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+                .thenReturn(Collections.emptyList());
+        when(matchingRepository.findMatchingCandidates(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
+                .thenReturn(Collections.emptyList());
+        // 3순위 대상 있음
+        when(matchingRepository.findMatchingCandidates(1L, TypeResult.NEWBIE, Gender.MAN, 1L, PageRequest.of(0, 1)))
+                .thenReturn(List.of(thirdPriorityCandidate));
 
-        Optional<Participant> result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
+        var result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
 
         assertThat(result).isPresent();
         assertThat(result.get().getTypeResult()).isEqualTo(TypeResult.NEWBIE);
@@ -205,12 +205,12 @@ class MatchingServiceImplTest {
         ReflectionTestUtils.setField(applicant, "participantId", 1L);
 
         // 대상이 존재하나 이미 매칭됨 (Repository에서 필터링 됨)
-        when(matchingRepository.findMatchingCandidate(1L, TypeResult.PHOTO, Gender.MAN, 1L))
-                .thenReturn(Optional.empty());
-        when(matchingRepository.findMatchingCandidate(1L, TypeResult.INFLUENCER, Gender.MAN, 1L))
-                .thenReturn(Optional.empty());
-        when(matchingRepository.findMatchingCandidate(1L, TypeResult.NEWBIE, Gender.MAN, 1L))
-                .thenReturn(Optional.empty());
+        when(matchingRepository.findMatchingCandidates(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+                .thenReturn(Collections.emptyList());
+        when(matchingRepository.findMatchingCandidates(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
+                .thenReturn(Collections.emptyList());
+        when(matchingRepository.findMatchingCandidates(1L, TypeResult.NEWBIE, Gender.MAN, 1L, PageRequest.of(0, 1)))
+                .thenReturn(Collections.emptyList());
 
         Optional<Participant> result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
 
@@ -229,9 +229,9 @@ class MatchingServiceImplTest {
                 .festival(festival)
                 .build();
 
-        when(matchingRepository.findMatchingCandidate(
-                applicant.getParticipantId(), TypeResult.PHOTO, Gender.MAN, festival.getFestivalId()
-        )).thenReturn(Optional.empty());
+        when(matchingRepository.findMatchingCandidates(
+                applicant.getParticipantId(), TypeResult.PHOTO, Gender.MAN, festival.getFestivalId(), PageRequest.of(0, 1)
+        )).thenReturn(Collections.emptyList());
 
         Optional<Participant> result = matchingService.findBestCandidateByPriority(
                 festival.getFestivalId(), applicant
@@ -239,5 +239,31 @@ class MatchingServiceImplTest {
 
         assertThat(result).isEmpty();
     }
+
+    @Test
+    @DisplayName("우선순위 기반 매칭 - 후보가 2명 이상일 때 첫 번째만 선택")
+    void findBestCandidate_multipleCandidates_returnsFirstOnly() {
+        // given
+        User applicantUser = mockUser("신청자", Gender.MAN, 1L);
+        Festival festival = mockFestival(applicantUser, 1L, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
+        Participant applicant = mockParticipant(applicantUser, festival, TypeResult.INFLUENCER, 1L);
+
+        User candidate1 = mockUser("후보1", Gender.WOMAN, 2L);
+        User candidate2 = mockUser("후보2", Gender.WOMAN, 3L);
+        Participant p1 = mockParticipant(candidate1, festival, TypeResult.PHOTO, 2L);
+        Participant p2 = mockParticipant(candidate2, festival, TypeResult.PHOTO, 3L);
+
+        // 후보 2명 반환
+        when(matchingRepository.findMatchingCandidates(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+                .thenReturn(List.of(p1, p2));
+
+        // when
+        var result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getUser().getNickname()).isEqualTo("후보1");
+    }
+
 
 }

--- a/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.festimate.team.common.mock.MockFactory.*;
 import static org.mockito.Mockito.when;
 
-public class MatchingServiceImplTest {
+class MatchingServiceImplTest {
     @Mock
     private MatchingRepository matchingRepository;
 


### PR DESCRIPTION
## 📌 PR 제목
[refactor] #72 N+1 문제 해결을 위한 매칭 후보자 탐색 쿼리 최적화

## 📌 PR 내용
### 매칭 요청 시 사용되는 후보자 탐색 쿼리에서 다음과 같은 구조적/성능적 문제를 해결했습니다:
- 기존 SIZE() 기반 중첩 서브쿼리를 GROUP BY + ORDER BY COUNT() 방식으로 변경하여 해석성과 확장성 향상
- Participant → User 연관 관계에서 발생하던 N+1 문제를 JOIN FETCH로 해결
- 쿼리 수 고정화, 중복 쿼리 제거, 유지보수성 개선

## 🛠 작업 내용
### ✅ 1. 후보자 탐색 쿼리 리팩터링
항목 | 변경 전 | 변경 후
-- | -- | --
매칭 수 계산 | SIZE() 중첩 + 서브쿼리 | GROUP BY COUNT() 정렬
정렬 기준 | MIN(SIZE()) 일치 대상만 추출 | 전체 대상 정렬 후 상위 1명 추출
user 접근 | Lazy (N+1 발생) | JOIN FETCH p.user 사용
실행 쿼리 수 | 8개 + 중복 발생 가능성 있음 | 고정 8개
SQL 실행 시간 | 약 26.0ms | 약 33.5ms
유지보수성 | 매우 낮음 | 정렬 기준 변경만으로 확장 가능

### ✅ 2. 서비스 로직/테스트 코드 대응
- 기존 Optional<Participant> 반환 → List<Participant>로 변경
- PageRequest.of(0, 1) 적용으로 반환은 1명이지만, 테스트에서는 후보 리스트 길이 확인 가능
- 후보가 여러 명일 때 정확히 1명만 선택하는지 확인하는 테스트 추가
- 없는 매칭 ID 조회 시 예외 처리 테스트 케이스 보완
- 매칭 대상이 null이거나 참가자가 없는 경우의 경계값 테스트도 반영

### ✅ 기대 효과
- user.gender 접근 시 Lazy Loading 제거로 인한 N+1 문제 해결
- COUNT() 기반 정렬 → 정렬 기준 추가/변경이 쉬움
- 테스트 및 예외 케이스 완비로 안정성 확보

## 🔍 관련 이슈
Closes #72 

## 📸 스크린샷 (Optional)
N/A

## 📚 레퍼런스 (Optional)
[🐌 JPA에서 Lazy 로딩, 정말 느린 걸까?](https://velog.io/@2hyunjinn/JPA%EC%97%90%EC%84%9C-Lazy-%EB%A1%9C%EB%94%A9-%EC%A0%95%EB%A7%90-%EB%8A%90%EB%A6%B0-%EA%B1%B8%EA%B9%8C)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved performance and reliability when selecting participants with the fewest matchings for candidate selection.
	- Added error handling for missing or invalid matching targets.
- **New Features**
	- Added pagination support when retrieving matching candidates.
- **Tests**
	- Updated test class visibility for improved encapsulation.
	- Removed unused imports from test files.
	- Added tests for error cases and candidate selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->