### PR TITLE
[fix] #116 메인화면에서 닉네임 조회 시 얼굴상 추가

### DIFF
--- a/src/main/java/org/festimate/team/api/user/UserController.java
+++ b/src/main/java/org/festimate/team/api/user/UserController.java
@@ -7,7 +7,8 @@ import org.festimate.team.api.facade.FestivalFacade;
 import org.festimate.team.api.facade.SignUpFacade;
 import org.festimate.team.api.user.dto.SignUpRequest;
 import org.festimate.team.api.user.dto.UserFestivalResponse;
-import org.festimate.team.api.user.dto.UserNicknameResponse;
+import org.festimate.team.api.user.dto.UserInfoResponse;
+import org.festimate.team.domain.user.dto.UserInfoDto;
 import org.festimate.team.domain.user.service.UserService;
 import org.festimate.team.domain.user.validator.UserRequestValidator;
 import org.festimate.team.global.response.ApiResponse;
@@ -54,12 +55,12 @@ public class UserController {
     }
 
     @GetMapping("/me/nickname")
-    public ResponseEntity<ApiResponse<UserNicknameResponse>> getNickname(
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getNickname(
             @RequestHeader("Authorization") String accessToken
     ) {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
-        String nickName = userService.getUserNickname(userId);
-        return ResponseBuilder.ok(UserNicknameResponse.from(nickName));
+        UserInfoDto userInfoDto = userService.getUserNicknameAndAppearanceType(userId);
+        return ResponseBuilder.ok(UserInfoResponse.from(userInfoDto.nickname(), userInfoDto.appearanceType()));
     }
 
     @GetMapping("/me/festivals")

--- a/src/main/java/org/festimate/team/api/user/dto/UserInfoResponse.java
+++ b/src/main/java/org/festimate/team/api/user/dto/UserInfoResponse.java
@@ -1,0 +1,12 @@
+package org.festimate.team.api.user.dto;
+
+import org.festimate.team.domain.user.entity.AppearanceType;
+
+public record UserInfoResponse(
+        String nickname,
+        AppearanceType appearanceType
+) {
+    public static UserInfoResponse from(String nickname, AppearanceType appearanceType) {
+        return new UserInfoResponse(nickname, appearanceType);
+    }
+}

--- a/src/main/java/org/festimate/team/api/user/dto/UserNicknameResponse.java
+++ b/src/main/java/org/festimate/team/api/user/dto/UserNicknameResponse.java
@@ -1,9 +1,0 @@
-package org.festimate.team.api.user.dto;
-
-public record UserNicknameResponse(
-        String nickname
-) {
-    public static UserNicknameResponse from(String nickname) {
-        return new UserNicknameResponse(nickname);
-    }
-}

--- a/src/main/java/org/festimate/team/domain/user/dto/UserInfoDto.java
+++ b/src/main/java/org/festimate/team/domain/user/dto/UserInfoDto.java
@@ -1,0 +1,10 @@
+package org.festimate.team.domain.user.dto;
+
+import org.festimate.team.domain.user.entity.AppearanceType;
+
+public record UserInfoDto(
+        String nickname,
+        AppearanceType appearanceType
+) {
+
+}

--- a/src/main/java/org/festimate/team/domain/user/service/UserService.java
+++ b/src/main/java/org/festimate/team/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package org.festimate.team.domain.user.service;
 
 import org.festimate.team.api.user.dto.SignUpRequest;
+import org.festimate.team.domain.user.dto.UserInfoDto;
 import org.festimate.team.domain.user.entity.Platform;
 import org.festimate.team.domain.user.entity.User;
 
@@ -15,7 +16,7 @@ public interface UserService {
 
     User signUp(SignUpRequest request, String platformId);
 
-    String getUserNickname(Long userId);
+    UserInfoDto getUserNicknameAndAppearanceType(Long userId);
 
     User getUserByIdOrThrow(Long userId);
 

--- a/src/main/java/org/festimate/team/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/user/service/impl/UserServiceImpl.java
@@ -3,6 +3,7 @@ package org.festimate.team.domain.user.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.festimate.team.api.user.dto.SignUpRequest;
+import org.festimate.team.domain.user.dto.UserInfoDto;
 import org.festimate.team.domain.user.entity.Platform;
 import org.festimate.team.domain.user.entity.User;
 import org.festimate.team.domain.user.repository.UserRepository;
@@ -50,9 +51,9 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public String getUserNickname(Long userId) {
-        getUserByIdOrThrow(userId);
-        return userRepository.findNicknameByUserId(userId);
+    public UserInfoDto getUserNicknameAndAppearanceType(Long userId) {
+        User user = getUserByIdOrThrow(userId);
+        return new UserInfoDto(user.getNickname(), user.getAppearanceType());
     }
 
     @Override


### PR DESCRIPTION
## 📌 PR 제목
[fix] #116 메인화면에서 닉네임 조회 시 얼굴상 추가

## 📌 PR 내용
- 메인페이지 사이드바에 사용자 프로필 이미지(얼굴상)를 함께 표시하기 위해 기존 닉네임 조회 API의 응답에 appearanceType 필드를 추가했습니다.

## 🛠 작업 내용
- [ ] API 응답에 appearanceType 포함되도록 변경
- [ ] UserInfoDto, UserInfoResponse DTO에 appearanceType 필드 추가
- [ ] UserService.getUserNicknameAndAppearanceType() 메서드 추가

## 🔍 관련 이슈
Closes #116 

## 📸 스크린샷 (Optional)
<img width="593" alt="image" src="https://github.com/user-attachments/assets/5729e3e5-2a08-4909-89fd-16de5270e583" />

## 📚 레퍼런스 (Optional)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- User information endpoint now provides both nickname and appearance type in responses.

- **Refactor**
	- User information responses have been updated to use a new format, replacing the previous nickname-only structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->