### PR TITLE
[fix] #119 다중 호스트로 변경 및 테스트 코드 추가

### DIFF
--- a/src/main/java/org/festimate/team/api/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/FestivalFacade.java
@@ -69,7 +69,8 @@ public class FestivalFacade {
 
     @Transactional(readOnly = true)
     public AdminFestivalDetailResponse getFestivalDetail(Long userId, Long festivalId) {
-        Festival festival = festivalService.getFestivalDetailByIdOrThrow(festivalId, userId);
+        User user = userService.getUserByIdOrThrow(userId);
+        Festival festival = festivalService.getFestivalDetailByIdOrThrow(festivalId, user);
         return AdminFestivalDetailResponse.of(festival);
     }
 

--- a/src/main/java/org/festimate/team/domain/festival/entity/Festival.java
+++ b/src/main/java/org/festimate/team/domain/festival/entity/Festival.java
@@ -5,14 +5,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.festimate.team.global.entity.BaseTimeEntity;
 import org.festimate.team.domain.matching.entity.Matching;
 import org.festimate.team.domain.participant.entity.Participant;
 import org.festimate.team.domain.user.entity.User;
+import org.festimate.team.global.entity.BaseTimeEntity;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -26,9 +27,8 @@ public class Festival extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long festivalId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "host_id", nullable = false)
-    private User host;
+    @OneToMany(mappedBy = "festival", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FestivalHost> festivalHosts = new ArrayList<>();
 
     @Column(nullable = false)
     private String title;
@@ -56,8 +56,7 @@ public class Festival extends BaseTimeEntity {
     private List<Matching> matchings;
 
     @Builder
-    public Festival(User host, String title, Category category, LocalDate startDate, LocalDate endDate, LocalDateTime matchingStartAt, String inviteCode) {
-        this.host = host;
+    public Festival(String title, Category category, LocalDate startDate, LocalDate endDate, LocalDateTime matchingStartAt, String inviteCode) {
         this.title = title;
         this.category = category;
         this.startDate = startDate;
@@ -90,4 +89,17 @@ public class Festival extends BaseTimeEntity {
             return FestivalStatus.BEFORE;
         } else return getFestivalStatus();
     }
+
+    public void addHost(User user) {
+        FestivalHost host = FestivalHost.builder()
+                .festival(this)
+                .host(user)
+                .build();
+        festivalHosts.add(host);
+    }
+
+    public void removeHost(User user) {
+        festivalHosts.removeIf(fh -> fh.getHost().equals(user));
+    }
+
 }

--- a/src/main/java/org/festimate/team/domain/festival/entity/Festival.java
+++ b/src/main/java/org/festimate/team/domain/festival/entity/Festival.java
@@ -91,11 +91,16 @@ public class Festival extends BaseTimeEntity {
     }
 
     public void addHost(User user) {
-        FestivalHost host = FestivalHost.builder()
-                .festival(this)
-                .host(user)
-                .build();
-        festivalHosts.add(host);
+        boolean alreadyExists = festivalHosts.stream()
+                .anyMatch(fh -> fh.getHost().getUserId().equals(user.getUserId()));
+
+        if (!alreadyExists) {
+            FestivalHost host = FestivalHost.builder()
+                    .festival(this)
+                    .host(user)
+                    .build();
+            festivalHosts.add(host);
+        }
     }
 
     public void removeHost(User user) {

--- a/src/main/java/org/festimate/team/domain/festival/entity/FestivalHost.java
+++ b/src/main/java/org/festimate/team/domain/festival/entity/FestivalHost.java
@@ -1,0 +1,55 @@
+package org.festimate.team.domain.festival.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.festimate.team.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "festival_host")
+public class FestivalHost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long festivalHostId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "festival_id", nullable = false)
+    private Festival festival;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User host;
+
+    @Column(nullable = false)
+    private LocalDateTime addedAt;
+
+    @Builder
+    public FestivalHost(Festival festival, User host) {
+        this.festival = festival;
+        this.host = host;
+        this.addedAt = LocalDateTime.now();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FestivalHost)) return false;
+        FestivalHost that = (FestivalHost) o;
+        return Objects.equals(getFestival(), that.getFestival()) &&
+                Objects.equals(getHost(), that.getHost());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getFestival(), getHost());
+    }
+
+}

--- a/src/main/java/org/festimate/team/domain/festival/entity/FestivalHost.java
+++ b/src/main/java/org/festimate/team/domain/festival/entity/FestivalHost.java
@@ -51,13 +51,18 @@ public class FestivalHost {
         if (this == o) return true;
         if (!(o instanceof FestivalHost)) return false;
         FestivalHost that = (FestivalHost) o;
-        return Objects.equals(getFestival(), that.getFestival()) &&
-                Objects.equals(getHost(), that.getHost());
+        return Objects.equals(
+                this.festival != null ? this.festival.getFestivalId() : null,
+                that.festival != null ? that.festival.getFestivalId() : null) &&
+                Objects.equals(
+                        this.host != null ? this.host.getUserId() : null,
+                        that.host != null ? that.host.getUserId() : null);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getFestival(), getHost());
+        return Objects.hash(
+                festival != null ? festival.getFestivalId() : null,
+                host != null ? host.getUserId() : null);
     }
-
 }

--- a/src/main/java/org/festimate/team/domain/festival/entity/FestivalHost.java
+++ b/src/main/java/org/festimate/team/domain/festival/entity/FestivalHost.java
@@ -13,7 +13,15 @@ import java.util.Objects;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "festival_host")
+@Table(
+        name = "festival_host",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_festival_host_festival_user",
+                        columnNames = {"festival_id", "user_id"}
+                )
+        }
+)
 public class FestivalHost {
 
     @Id

--- a/src/main/java/org/festimate/team/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/org/festimate/team/domain/festival/repository/FestivalRepository.java
@@ -14,5 +14,5 @@ public interface FestivalRepository extends JpaRepository<Festival, Integer> {
 
     Optional<Festival> findByFestivalId(Long festivalId);
 
-    List<Festival> findFestivalByHost(User host);
+    List<Festival> findDistinctByFestivalHosts_Host(User host);
 }

--- a/src/main/java/org/festimate/team/domain/festival/service/FestivalService.java
+++ b/src/main/java/org/festimate/team/domain/festival/service/FestivalService.java
@@ -15,7 +15,7 @@ public interface FestivalService {
 
     List<Festival> getAllFestivals(User user);
 
-    Festival getFestivalDetailByIdOrThrow(Long festivalId, Long userId);
+    Festival getFestivalDetailByIdOrThrow(Long festivalId, User user);
 
     boolean isHost(User user, Festival festival);
 

--- a/src/test/java/org/festimate/team/api/facade/FestivalFacadeTest.java
+++ b/src/test/java/org/festimate/team/api/facade/FestivalFacadeTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.festimate.team.global.util.DateFormatter.formatPeriod;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 class FestivalFacadeTest {
@@ -147,7 +149,8 @@ class FestivalFacadeTest {
         // given
         Festival festival = MockFactory.mockFestival(user, 1L, LocalDate.now(), LocalDate.now().plusDays(1));
 
-        when(festivalService.getFestivalDetailByIdOrThrow(1L, 1L)).thenReturn(festival);
+        when(userService.getUserByIdOrThrow(eq(1L))).thenReturn(user);
+        when(festivalService.getFestivalDetailByIdOrThrow(eq(1L), any(User.class))).thenReturn(festival); // ⭐ 핵심
 
         // when
         var response = festivalFacade.getFestivalDetail(1L, 1L);

--- a/src/test/java/org/festimate/team/common/mock/MockFactory.java
+++ b/src/test/java/org/festimate/team/common/mock/MockFactory.java
@@ -2,6 +2,7 @@ package org.festimate.team.common.mock;
 
 import org.festimate.team.domain.festival.entity.Category;
 import org.festimate.team.domain.festival.entity.Festival;
+import org.festimate.team.domain.festival.entity.FestivalHost;
 import org.festimate.team.domain.participant.entity.Participant;
 import org.festimate.team.domain.participant.entity.TypeResult;
 import org.festimate.team.domain.user.entity.*;
@@ -30,13 +31,17 @@ public class MockFactory {
 
     public static Festival mockFestival(User host, long id, LocalDate startDate, LocalDate endDate) {
         Festival festival = Festival.builder()
-                .host(host)
                 .title("모의 페스티벌")
                 .category(Category.LIFE)
                 .startDate(startDate)
                 .endDate(endDate)
                 .matchingStartAt(startDate.atStartOfDay().plusHours(1))
                 .inviteCode("MOCK123")
+                .build();
+
+        FestivalHost festivalHost = FestivalHost.builder()
+                .festival(festival)
+                .host(host)
                 .build();
 
         ReflectionTestUtils.setField(festival, "festivalId", id);

--- a/src/test/java/org/festimate/team/domain/festival/service/impl/FestivalServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/festival/service/impl/FestivalServiceImplTest.java
@@ -39,7 +39,7 @@ class FestivalServiceImplTest {
         Festival festival2 = MockFactory.mockFestival(host, 2L, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
         List<Festival> expectedFestivals = List.of(festival1, festival2);
 
-        when(festivalRepository.findFestivalByHost(host)).thenReturn(expectedFestivals);
+        when(festivalRepository.findDistinctByFestivalHosts_Host(host)).thenReturn(expectedFestivals);
 
         // when
         List<Festival> result = festivalService.getAllFestivals(host);
@@ -47,5 +47,32 @@ class FestivalServiceImplTest {
         // then
         assertThat(result).hasSize(2);
         assertThat(result).containsExactly(festival1, festival2);
+    }
+
+
+    @Test
+    @DisplayName("동일한 페스티벌에 여러 호스트가 있을 때, 각 호스트의 조회 결과에 동일한 페스티벌이 반환된다")
+    void getAllFestivals_multipleHosts_returnSameFestival() {
+        // given
+        User host1 = MockFactory.mockUser("1호스트", Gender.MAN, 1L);
+        User host2 = MockFactory.mockUser("2호스트", Gender.MAN, 2L);
+        Festival festival = MockFactory.mockFestival(host1, 1L, LocalDate.now(), LocalDate.now().plusDays(2));
+        festival.addHost(host2);
+
+        List<Festival> expectedFestival1 = List.of(festival);
+        List<Festival> expectedFestival2 = List.of(festival);
+
+        when(festivalRepository.findDistinctByFestivalHosts_Host(host1)).thenReturn(expectedFestival1);
+        when(festivalRepository.findDistinctByFestivalHosts_Host(host2)).thenReturn(expectedFestival2);
+
+        // when
+        List<Festival> result1 = festivalService.getAllFestivals(host1);
+        List<Festival> result2 = festivalService.getAllFestivals(host2);
+
+        // then
+        assertThat(result1).hasSize(1);
+        assertThat(result2).hasSize(1);
+        assertThat(result1).containsExactly(festival);
+        assertThat(result2).containsExactly(festival);
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
[fix] #119 다중 호스트로 변경 및 테스트 코드 추가

## 📌 PR 내용
- 하나의 페스티벌에 여러 명의 호스트를 등록할 수 있도록 기능을 확장했습니다.
- 각 호스트가 getAllFestivals() 호출 시 동일한 페스티벌이 조회되는지 확인하는 단위 테스트를 추가했습니다.
- 관련 로직이 포함된 FestivalFacade, FestivalServiceImpl, FestivalRepository를 수정했습니다.

## 🛠 작업 내용
- [ ] 다중 호스트 등록 가능하도록 Festival → FestivalHost 관계 수정
- [ ] FestivalRepository에 findDistinctByFestivalHosts_Host() 메서드 정의
- [ ] FestivalServiceImpl.getAllFestivals() 내부 로직 수정
- [ ] FestivalServiceImplTest에 다중 호스트 조회 테스트 코드 추가
- [ ] FestivalFacade에서 user 조회 로직 개선 (직접 ID 전달하지 않도록)

## 🔍 관련 이슈
Closes #119 

## 📸 스크린샷 (Optional)
<img width="240" alt="image" src="https://github.com/user-attachments/assets/d02cb7d5-84de-4499-ad16-230899212ed4" />

## 📚 레퍼런스 (Optional)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for multiple hosts per festival, enabling association with several host users.

- **Bug Fixes**
  - Enhanced host authorization to accommodate multiple hosts per festival.

- **Tests**
  - Added and updated tests to ensure consistent festival retrieval and correct behavior with multiple hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->