### PR TITLE
[feat] #128 포인트 차감 기능 구현 및 트랜잭션 타입 분기 처리

### DIFF
--- a/src/main/java/org/festimate/team/api/facade/PointFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/PointFacade.java
@@ -7,6 +7,7 @@ import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.service.FestivalService;
 import org.festimate.team.domain.participant.entity.Participant;
 import org.festimate.team.domain.participant.service.ParticipantService;
+import org.festimate.team.domain.point.entity.TransactionType;
 import org.festimate.team.domain.point.service.PointService;
 import org.festimate.team.domain.user.entity.User;
 import org.festimate.team.domain.user.service.UserService;
@@ -51,7 +52,12 @@ public class PointFacade {
         if (participant.getFestival() != festival) {
             throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
         }
-        pointService.rechargePoint(participant, request.point());
+
+        if(request.type().equals(TransactionType.CREDIT)) {
+            pointService.rechargePoint(participant, request.point());
+        }else if (request.type().equals(TransactionType.DEBIT)) {
+            pointService.dischargePoint(participant, request.point());
+        }
     }
 
     private void isHost(User user, Festival festival) {

--- a/src/main/java/org/festimate/team/api/point/dto/RechargePointRequest.java
+++ b/src/main/java/org/festimate/team/api/point/dto/RechargePointRequest.java
@@ -1,6 +1,9 @@
 package org.festimate.team.api.point.dto;
 
+import org.festimate.team.domain.point.entity.TransactionType;
+
 public record RechargePointRequest(
+        TransactionType type,
         long participantId,
         int point
 ) {

--- a/src/main/java/org/festimate/team/domain/point/service/PointService.java
+++ b/src/main/java/org/festimate/team/domain/point/service/PointService.java
@@ -14,4 +14,8 @@ public interface PointService {
 
     @Transactional
     void rechargePoint(Participant participant, int amount);
+
+    @Transactional
+    void dischargePoint(Participant participant, int amount);
+
 }

--- a/src/main/java/org/festimate/team/domain/point/service/impl/PointServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/point/service/impl/PointServiceImpl.java
@@ -4,13 +4,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.festimate.team.api.point.dto.PointHistory;
 import org.festimate.team.api.point.dto.PointHistoryResponse;
+import org.festimate.team.domain.participant.entity.Participant;
 import org.festimate.team.domain.point.entity.Point;
 import org.festimate.team.domain.point.entity.TransactionType;
 import org.festimate.team.domain.point.repository.PointRepository;
 import org.festimate.team.domain.point.service.PointService;
-import org.festimate.team.global.response.ResponseError;
 import org.festimate.team.global.exception.FestimateException;
-import org.festimate.team.domain.participant.entity.Participant;
+import org.festimate.team.global.response.ResponseError;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +51,17 @@ public class PointServiceImpl implements PointService {
     @Override
     public void rechargePoint(Participant participant, int amount) {
         Point pointUsage = createPointTransaction(participant, amount, TransactionType.CREDIT);
+        pointRepository.save(pointUsage);
+    }
+
+    @Transactional
+    @Override
+    public void dischargePoint(Participant participant, int amount) {
+        int totalPoint = getTotalPointByParticipant(participant);
+        if (totalPoint < amount) {
+            throw new FestimateException(ResponseError.INSUFFICIENT_POINTS);
+        }
+        Point pointUsage = createPointTransaction(participant, amount, TransactionType.DEBIT);
         pointRepository.save(pointUsage);
     }
 

--- a/src/test/java/org/festimate/team/api/facade/PointFacadeTest.java
+++ b/src/test/java/org/festimate/team/api/facade/PointFacadeTest.java
@@ -7,6 +7,7 @@ import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.service.FestivalService;
 import org.festimate.team.domain.participant.entity.Participant;
 import org.festimate.team.domain.participant.service.ParticipantService;
+import org.festimate.team.domain.point.entity.TransactionType;
 import org.festimate.team.domain.point.service.PointService;
 import org.festimate.team.domain.user.entity.Gender;
 import org.festimate.team.domain.user.entity.User;
@@ -97,7 +98,7 @@ class PointFacadeTest {
     @DisplayName("포인트 충전 성공 (호스트 권한)")
     void rechargePoints_success() {
         // given
-        RechargePointRequest request = new RechargePointRequest(200L, 5);
+        RechargePointRequest request = new RechargePointRequest(TransactionType.CREDIT, 200L, 5);
 
         when(userService.getUserByIdOrThrow(1L)).thenReturn(host);
         when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
@@ -115,7 +116,7 @@ class PointFacadeTest {
     @DisplayName("포인트 충전 실패 - 호스트가 아님")
     void rechargePoints_notHost_throws() {
         User attacker = MockFactory.mockUser("악당", Gender.MAN, 999L);
-        RechargePointRequest request = new RechargePointRequest(200L, 5);
+        RechargePointRequest request = new RechargePointRequest(TransactionType.CREDIT, 200L, 5);
 
         when(userService.getUserByIdOrThrow(999L)).thenReturn(attacker);
         when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);
@@ -133,7 +134,7 @@ class PointFacadeTest {
         Festival otherFestival = MockFactory.mockFestival(host, 999L, LocalDate.now(), LocalDate.now().plusDays(1));
         Participant otherParticipant = MockFactory.mockParticipant(participantUser, otherFestival, null, 300L);
 
-        RechargePointRequest request = new RechargePointRequest(300L, 5);
+        RechargePointRequest request = new RechargePointRequest(TransactionType.CREDIT, 300L, 5);
 
         when(userService.getUserByIdOrThrow(1L)).thenReturn(host);
         when(festivalService.getFestivalByIdOrThrow(100L)).thenReturn(festival);


### PR DESCRIPTION
## 📌 PR 제목
[feat] #128 포인트 차감 기능 구현 및 트랜잭션 타입 분기 처리

## 📌 PR 내용
- 포인트 트랜잭션에 CREDIT / DEBIT 타입 분기 처리 추가
- 포인트 차감 기능(dischargePoint) 구현
- 잔여 포인트가 부족한 경우 예외 처리 추가
- 관련 테스트 코드 수정 및 분기 케이스 커버

## 🛠 작업 내용
- [x] 포인트 차감 기능 구현
- [x] 트랜잭션 타입(CREDIT / DEBIT) 분기 처리
- [x] 포인트 차감 시 잔액 부족 체크
- [x] 테스트 코드 수정 및 추가

## 🔍 관련 이슈
Closes #128 

## 📸 스크린샷 (Optional)
![image](https://github.com/user-attachments/assets/f49420bf-7776-4714-a8e6-a4a22a58aa31)

## 📚 레퍼런스 (Optional)
트랜잭션 타입 분기 처리는 기존 TransactionType enum 기반으로 처리하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for both crediting and debiting participant points in the point management system.
	- Users can now specify the transaction type (credit or debit) when adjusting points.
- **Bug Fixes**
	- Improved validation to prevent debiting more points than available.
- **Tests**
	- Updated tests to cover the new transaction type parameter for point adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->