### PR TITLE
[feat] #131 유저별 매칭 현황 조회 API 구현 및 Service → Facade 책임 분리

### DIFF
--- a/src/main/java/org/festimate/team/api/admin/AdminController.java
+++ b/src/main/java/org/festimate/team/api/admin/AdminController.java
@@ -3,10 +3,10 @@ package org.festimate.team.api.admin;
 import lombok.RequiredArgsConstructor;
 import org.festimate.team.api.admin.dto.*;
 import org.festimate.team.api.facade.FestivalFacade;
+import org.festimate.team.api.facade.MatchingFacade;
 import org.festimate.team.api.facade.ParticipantFacade;
 import org.festimate.team.api.facade.PointFacade;
 import org.festimate.team.api.point.dto.PointHistoryResponse;
-import org.festimate.team.api.point.dto.RechargePointRequest;
 import org.festimate.team.global.response.ApiResponse;
 import org.festimate.team.global.response.ResponseBuilder;
 import org.festimate.team.infra.jwt.JwtService;
@@ -23,6 +23,7 @@ public class AdminController {
     private final FestivalFacade festivalFacade;
     private final ParticipantFacade participantFacade;
     private final PointFacade pointFacade;
+    private final MatchingFacade matchingFacade;
 
     @PostMapping()
     public ResponseEntity<ApiResponse<FestivalResponse>> createFestival(
@@ -84,6 +85,17 @@ public class AdminController {
     ) {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
         PointHistoryResponse response = pointFacade.getParticipantPointHistory(userId, festivalId, participantId);
+        return ResponseBuilder.ok(response);
+    }
+
+    @GetMapping("/{festivalId}/participants/{participantId}/matchings")
+    public ResponseEntity<ApiResponse<AdminMatchingResponse>> getParticipantMatchingHistory(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @PathVariable("participantId") Long participantId
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        AdminMatchingResponse response = matchingFacade.getMatchingSize(userId, festivalId, participantId);
         return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/api/admin/dto/AdminMatchingResponse.java
+++ b/src/main/java/org/festimate/team/api/admin/dto/AdminMatchingResponse.java
@@ -1,0 +1,10 @@
+package org.festimate.team.api.admin.dto;
+
+public record AdminMatchingResponse(
+        int successMatchings,
+        int totalMatchings
+) {
+    public static AdminMatchingResponse from(int successMatchings, int totalMatchings) {
+        return new AdminMatchingResponse(successMatchings, totalMatchings);
+    }
+}

--- a/src/main/java/org/festimate/team/api/admin/dto/RechargePointRequest.java
+++ b/src/main/java/org/festimate/team/api/admin/dto/RechargePointRequest.java
@@ -1,4 +1,4 @@
-package org.festimate.team.api.point.dto;
+package org.festimate.team.api.admin.dto;
 
 import org.festimate.team.domain.point.entity.TransactionType;
 

--- a/src/main/java/org/festimate/team/api/facade/MatchingFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/MatchingFacade.java
@@ -2,6 +2,9 @@ package org.festimate.team.api.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.festimate.team.api.admin.dto.AdminMatchingResponse;
+import org.festimate.team.api.matching.dto.MatchingDetailInfo;
+import org.festimate.team.api.matching.dto.MatchingListResponse;
+import org.festimate.team.api.matching.dto.MatchingStatusResponse;
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.service.FestivalService;
 import org.festimate.team.domain.matching.service.MatchingService;
@@ -22,6 +25,33 @@ public class MatchingFacade {
     private final FestivalService festivalService;
     private final ParticipantService participantService;
     private final MatchingService matchingService;
+
+    @Transactional
+    public MatchingStatusResponse createMatching(Long userId, Long festivalId) {
+        User user = userService.getUserByIdOrThrow(userId);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        Participant participant = participantService.getParticipant(user, festival);
+
+        return matchingService.createMatching(participant, festival);
+    }
+
+    @Transactional(readOnly = true)
+    public MatchingListResponse getMatchingList(Long userId, Long festivalId) {
+        User user = userService.getUserByIdOrThrow(userId);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        Participant participant = participantService.getParticipant(user, festival);
+
+        return matchingService.getMatchingList(participant);
+    }
+
+    @Transactional(readOnly = true)
+    public MatchingDetailInfo getMatchingDetail(Long userId, Long festivalId, Long matchingId) {
+        User user = userService.getUserByIdOrThrow(userId);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        Participant participant = participantService.getParticipant(user, festival);
+
+        return matchingService.getMatchingDetail(participant, festival, matchingId);
+    }
 
     @Transactional(readOnly = true)
     public AdminMatchingResponse getMatchingSize(Long userId, Long festivalId, Long participantId) {

--- a/src/main/java/org/festimate/team/api/facade/MatchingFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/MatchingFacade.java
@@ -1,0 +1,41 @@
+package org.festimate.team.api.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.festimate.team.api.admin.dto.AdminMatchingResponse;
+import org.festimate.team.domain.festival.entity.Festival;
+import org.festimate.team.domain.festival.service.FestivalService;
+import org.festimate.team.domain.matching.service.MatchingService;
+import org.festimate.team.domain.participant.entity.Participant;
+import org.festimate.team.domain.participant.service.ParticipantService;
+import org.festimate.team.domain.user.entity.User;
+import org.festimate.team.domain.user.service.UserService;
+import org.festimate.team.global.exception.FestimateException;
+import org.festimate.team.global.response.ResponseError;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class MatchingFacade {
+
+    private final UserService userService;
+    private final FestivalService festivalService;
+    private final ParticipantService participantService;
+    private final MatchingService matchingService;
+
+    @Transactional(readOnly = true)
+    public AdminMatchingResponse getMatchingSize(Long userId, Long festivalId, Long participantId) {
+        User user = userService.getUserByIdOrThrow(userId);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        isHost(user, festival);
+        Participant participant = participantService.getParticipantById(participantId);
+
+        return matchingService.getMatchingSize(participant);
+    }
+
+    private void isHost(User user, Festival festival) {
+        if (!festivalService.isHost(user, festival)) {
+            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
+        }
+    }
+}

--- a/src/main/java/org/festimate/team/api/facade/PointFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/PointFacade.java
@@ -2,7 +2,7 @@ package org.festimate.team.api.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.festimate.team.api.point.dto.PointHistoryResponse;
-import org.festimate.team.api.point.dto.RechargePointRequest;
+import org.festimate.team.api.admin.dto.RechargePointRequest;
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.service.FestivalService;
 import org.festimate.team.domain.participant.entity.Participant;

--- a/src/main/java/org/festimate/team/api/matching/MatchingController.java
+++ b/src/main/java/org/festimate/team/api/matching/MatchingController.java
@@ -1,10 +1,10 @@
 package org.festimate.team.api.matching;
 
 import lombok.RequiredArgsConstructor;
+import org.festimate.team.api.facade.MatchingFacade;
 import org.festimate.team.api.matching.dto.MatchingDetailInfo;
 import org.festimate.team.api.matching.dto.MatchingListResponse;
 import org.festimate.team.api.matching.dto.MatchingStatusResponse;
-import org.festimate.team.domain.matching.service.MatchingService;
 import org.festimate.team.global.response.ApiResponse;
 import org.festimate.team.global.response.ResponseBuilder;
 import org.festimate.team.infra.jwt.JwtService;
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/festivals")
 @RequiredArgsConstructor
 public class MatchingController {
-    private final MatchingService matchingService;
+    private final MatchingFacade matchingFacade;
     private final JwtService jwtService;
 
     @PostMapping("/{festivalId}/matchings")
@@ -25,7 +25,7 @@ public class MatchingController {
     ) {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
 
-        MatchingStatusResponse response = matchingService.createMatching(userId, festivalId);
+        MatchingStatusResponse response = matchingFacade.createMatching(userId, festivalId);
         return ResponseBuilder.created(response);
     }
 
@@ -36,7 +36,7 @@ public class MatchingController {
     ) {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
 
-        MatchingListResponse response = matchingService.getMatchingList(userId, festivalId);
+        MatchingListResponse response = matchingFacade.getMatchingList(userId, festivalId);
         return ResponseBuilder.ok(response);
     }
 
@@ -48,7 +48,7 @@ public class MatchingController {
     ) {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
 
-        MatchingDetailInfo response = matchingService.getMatchingDetail(userId, festivalId, matchingId);
+        MatchingDetailInfo response = matchingFacade.getMatchingDetail(userId, festivalId, matchingId);
         return ResponseBuilder.ok(response);
     }
 }

--- a/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
@@ -71,6 +71,12 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             """)
     List<Matching> findAllMatchingsByApplicantParticipant(Participant participant);
 
+    @Query("SELECT COUNT(m) FROM Matching m WHERE m.applicantParticipant = :participant")
+    int countAllByApplicant(@Param("participant") Participant participant);
+
+    @Query("SELECT COUNT(m) FROM Matching m WHERE m.applicantParticipant = :participant AND m.status = 'COMPLETED'")
+    int countCompletedByApplicant(@Param("participant") Participant participant);
+
     Optional<Matching> findByMatchingId(Long matchingId);
 }
 

--- a/src/main/java/org/festimate/team/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/MatchingService.java
@@ -1,5 +1,6 @@
 package org.festimate.team.domain.matching.service;
 
+import org.festimate.team.api.admin.dto.AdminMatchingResponse;
 import org.festimate.team.api.matching.dto.MatchingDetailInfo;
 import org.festimate.team.api.matching.dto.MatchingListResponse;
 import org.festimate.team.api.matching.dto.MatchingStatusResponse;
@@ -11,6 +12,8 @@ public interface MatchingService {
     MatchingStatusResponse createMatching(Long userId, Long festivalId);
 
     MatchingListResponse getMatchingList(Long userId, Long festivalId);
+
+    AdminMatchingResponse getMatchingSize(Participant participant);
 
     MatchingDetailInfo getMatchingDetail(Long userId, Long festivalId, Long matchingId);
 

--- a/src/main/java/org/festimate/team/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/MatchingService.java
@@ -4,18 +4,19 @@ import org.festimate.team.api.admin.dto.AdminMatchingResponse;
 import org.festimate.team.api.matching.dto.MatchingDetailInfo;
 import org.festimate.team.api.matching.dto.MatchingListResponse;
 import org.festimate.team.api.matching.dto.MatchingStatusResponse;
+import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.participant.entity.Participant;
 
 import java.util.Optional;
 
 public interface MatchingService {
-    MatchingStatusResponse createMatching(Long userId, Long festivalId);
+    MatchingStatusResponse createMatching(Participant participant, Festival festival);
 
-    MatchingListResponse getMatchingList(Long userId, Long festivalId);
+    MatchingListResponse getMatchingList(Participant participant);
 
     AdminMatchingResponse getMatchingSize(Participant participant);
 
-    MatchingDetailInfo getMatchingDetail(Long userId, Long festivalId, Long matchingId);
+    MatchingDetailInfo getMatchingDetail(Participant participant, Festival festival, Long matchingId);
 
     Optional<Participant> findBestCandidateByPriority(long festivalId, Participant participant);
 

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -2,6 +2,7 @@ package org.festimate.team.domain.matching.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.api.admin.dto.AdminMatchingResponse;
 import org.festimate.team.api.matching.dto.MatchingDetailInfo;
 import org.festimate.team.api.matching.dto.MatchingInfo;
 import org.festimate.team.api.matching.dto.MatchingListResponse;
@@ -68,6 +69,14 @@ public class MatchingServiceImpl implements MatchingService {
 
         List<MatchingInfo> matchings = getMatchingListByParticipant(participant);
         return MatchingListResponse.from(matchings);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public AdminMatchingResponse getMatchingSize(Participant participant) {
+        int allMatchingSize = matchingRepository.countAllByApplicant(participant);
+        int completeMatchingSize = matchingRepository.countCompletedByApplicant(participant);
+        return AdminMatchingResponse.from(completeMatchingSize, allMatchingSize);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/org/festimate/team/api/facade/PointFacadeTest.java
+++ b/src/test/java/org/festimate/team/api/facade/PointFacadeTest.java
@@ -1,7 +1,7 @@
 package org.festimate.team.api.facade;
 
 import org.festimate.team.api.point.dto.PointHistoryResponse;
-import org.festimate.team.api.point.dto.RechargePointRequest;
+import org.festimate.team.api.admin.dto.RechargePointRequest;
 import org.festimate.team.common.mock.MockFactory;
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.festival.service.FestivalService;

--- a/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
@@ -94,7 +94,7 @@ class MatchingServiceImplTest {
                 .thenReturn(List.of(matching2, matching1));
 
         // when
-        MatchingListResponse result = matchingService.getMatchingList(user.getUserId(), festival.getFestivalId());
+        MatchingListResponse result = matchingService.getMatchingList(participant);
 
         // then
         assertThat(result.matchingList()).hasSize(2);
@@ -268,7 +268,7 @@ class MatchingServiceImplTest {
         when(matchingRepository.findByMatchingId(1L)).thenReturn(Optional.of(mismatchedMatching));
 
         // when & then
-        assertThatThrownBy(() -> matchingService.getMatchingDetail(user.getUserId(), requestedFestival.getFestivalId(), 1L))
+        assertThatThrownBy(() -> matchingService.getMatchingDetail(participant, requestedFestival, 1L))
                 .isInstanceOf(FestimateException.class)
                 .hasMessage(ResponseError.FORBIDDEN_RESOURCE.getMessage());
     }
@@ -296,7 +296,7 @@ class MatchingServiceImplTest {
         when(matchingRepository.findByMatchingId(1L)).thenReturn(Optional.of(mismatchedMatching));
 
         // when & then
-        assertThatThrownBy(() -> matchingService.getMatchingDetail(user.getUserId(), requestedFestival.getFestivalId(), 1L))
+        assertThatThrownBy(() -> matchingService.getMatchingDetail(participant, requestedFestival, 1L))
                 .isInstanceOf(FestimateException.class)
                 .hasMessage(ResponseError.TARGET_NOT_FOUND.getMessage());
     }
@@ -325,7 +325,7 @@ class MatchingServiceImplTest {
                 .thenReturn(Optional.ofNullable(mismatchedMatching));
 
         // when & then
-        assertThatThrownBy(() -> matchingService.getMatchingDetail(user.getUserId(), festival.getFestivalId(), 2L))
+        assertThatThrownBy(() -> matchingService.getMatchingDetail(participant, festival, 2L))
                 .isInstanceOf(FestimateException.class)
                 .hasMessage(ResponseError.TARGET_NOT_FOUND.getMessage());
     }


### PR DESCRIPTION
## 📌 PR 제목
[feat] #131 유저별 매칭 현황 조회 API 구현 및 Service → Facade 책임 분리

## 📌 PR 내용
- 어드민이 특정 참가자의 매칭 성공 수 / 시도 수를 조회할 수 있는 API를 구현했습니다.
- 기존 MatchingServiceImpl에서 처리하던 사용자, 페스티벌, 참가자 조회 로직을 MatchingFacade로 이동하여
   계층 간 책임을 명확히 분리했습니다.
- JWT 파싱 및 권한 검증 역시 Facade에서 일괄 처리되도록 구조를 정리했습니다.

## 🛠 작업 내용
- [x] 기능 추가: 참가자 매칭 통계 조회 API (GET /v1/admin/festivals/{festivalId}/participants/{participantId}/matchings)
- [x] 리팩토링: Service → Facade로 유저, 페스티벌, 참가자 조회 책임 이동
- [x] 응답 포맷 통일 및 예외 처리 통합

## 🔍 관련 이슈
Closes #131 

## 📸 스크린샷 (Optional)
<img width="741" alt="image" src="https://github.com/user-attachments/assets/9f4cf28c-bffc-40f6-8e3b-b34acb8459fa" />

## 📚 레퍼런스 (Optional)
- JWT 파싱 및 isHost() 검증 기존 로직
- MatchingRepository 내 countAllByApplicant / countCompletedByApplicant 메서드 사용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an admin endpoint to view the matching history (total and successful matchings) for a festival participant.
- **Refactor**
  - Updated matching-related services and controllers to use domain entities instead of IDs for improved consistency and clarity.
- **Bug Fixes**
  - Removed unused imports and updated import paths for improved code maintenance.
- **Tests**
  - Updated tests to reflect changes in method signatures and usage of domain entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->