### PR TITLE
[fix] #133 초대코드 검증 시 참가자 중복 여부 확인

### DIFF
--- a/src/main/java/org/festimate/team/api/facade/FestivalFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/FestivalFacade.java
@@ -14,6 +14,8 @@ import org.festimate.team.domain.festival.service.FestivalService;
 import org.festimate.team.domain.participant.service.ParticipantService;
 import org.festimate.team.domain.user.entity.User;
 import org.festimate.team.domain.user.service.UserService;
+import org.festimate.team.global.exception.FestimateException;
+import org.festimate.team.global.response.ResponseError;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,8 +29,12 @@ public class FestivalFacade {
     private final ParticipantService participantService;
 
     @Transactional(readOnly = true)
-    public FestivalVerifyResponse verifyFestival(FestivalVerifyRequest request) {
+    public FestivalVerifyResponse verifyFestival(Long userId, FestivalVerifyRequest request) {
+        User user = userService.getUserByIdOrThrow(userId);
         Festival festival = festivalService.getFestivalByInviteCode(request.inviteCode().trim());
+        if (participantService.getParticipant(user, festival) != null) {
+            throw new FestimateException(ResponseError.PARTICIPANT_ALREADY_EXISTS);
+        }
         return FestivalVerifyResponse.of(festival);
     }
 

--- a/src/main/java/org/festimate/team/api/festival/FestivalController.java
+++ b/src/main/java/org/festimate/team/api/festival/FestivalController.java
@@ -2,7 +2,9 @@ package org.festimate.team.api.festival;
 
 import lombok.RequiredArgsConstructor;
 import org.festimate.team.api.facade.FestivalFacade;
-import org.festimate.team.api.festival.dto.*;
+import org.festimate.team.api.festival.dto.FestivalInfoResponse;
+import org.festimate.team.api.festival.dto.FestivalVerifyRequest;
+import org.festimate.team.api.festival.dto.FestivalVerifyResponse;
 import org.festimate.team.global.response.ApiResponse;
 import org.festimate.team.global.response.ResponseBuilder;
 import org.festimate.team.infra.jwt.JwtService;
@@ -21,8 +23,8 @@ public class FestivalController {
             @RequestHeader("Authorization") String accessToken,
             @RequestBody FestivalVerifyRequest request
     ) {
-        jwtService.parseTokenAndGetUserId(accessToken);
-        FestivalVerifyResponse response = festivalFacade.verifyFestival(request);
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        FestivalVerifyResponse response = festivalFacade.verifyFestival(userId, request);
         return ResponseBuilder.ok(response);
     }
 

--- a/src/test/java/org/festimate/team/api/facade/FestivalFacadeTest.java
+++ b/src/test/java/org/festimate/team/api/facade/FestivalFacadeTest.java
@@ -58,7 +58,7 @@ class FestivalFacadeTest {
         when(festivalService.getFestivalByInviteCode("MOCK123")).thenReturn(festival);
 
         // when
-        var response = festivalFacade.verifyFestival(request);
+        var response = festivalFacade.verifyFestival(user.getUserId(), request);
 
         // then
         assertThat(response.festivalId()).isEqualTo(1L);


### PR DESCRIPTION
## 📌 PR 제목
[fix] #133 초대코드 검증 시 참가자 중복 여부 확인

## 📌 PR 내용
- 초대코드 검증 시 이미 참가자인 유저에 대해 중복 참가를 방지하도록 로직을 보완했습니다.
- 기존에는 참가자 생성 시에만 중복 여부를 확인했으나, 초대코드 검증 단계에서 선제적으로 확인하여 UX를 개선했습니다.

## 🛠 작업 내용
- [x] 초대코드 검증 시 참가자 중복 여부 확인 로직 추가
- [x] 중복일 경우 PARTICIPANT_ALREADY_EXISTS 예외 반환
- [x] verifyFestival 메서드 시그니처 변경 (userId 추가)
- [x] 컨트롤러 및 테스트 코드 수정 반영

## 🔍 관련 이슈
Closes #133 

## 📸 스크린샷 (Optional)
<img width="701" alt="image" src="https://github.com/user-attachments/assets/45a52686-f7f2-46b2-b7f5-7f47cf082b3b" />

## 📚 레퍼런스 (Optional)
N/A