### PR TITLE
[fix] #135 닉네임 검증 시 한글 -> 한글, 영어로 변경

### DIFF
--- a/src/main/java/org/festimate/team/domain/user/validator/NicknameValidator.java
+++ b/src/main/java/org/festimate/team/domain/user/validator/NicknameValidator.java
@@ -1,8 +1,8 @@
 package org.festimate.team.domain.user.validator;
 
+import org.festimate.team.global.exception.FestimateException;
 import org.festimate.team.global.response.ResponseError;
 import org.festimate.team.global.validator.LengthValidator;
-import org.festimate.team.global.exception.FestimateException;
 import org.springframework.stereotype.Component;
 
 import java.util.regex.Pattern;
@@ -11,12 +11,12 @@ import java.util.regex.Pattern;
 public class NicknameValidator {
     private static final int MIN_LENGTH = 2;
     private static final int MAX_LENGTH = 6;
-    private static final Pattern koreanPattern = Pattern.compile("^[가-힣]+$");
+    private static final Pattern nicknamePattern = Pattern.compile("^[가-힣a-zA-Z]+$");
 
     public void validate(String nickname) {
         if (!LengthValidator.rangeLengthCheck(nickname, MIN_LENGTH, MAX_LENGTH))
             throw new FestimateException(ResponseError.INVALID_INPUT_LENGTH);
-        if (!koreanPattern.matcher(nickname).find())
+        if (!nicknamePattern.matcher(nickname).find())
             throw new FestimateException(ResponseError.INVALID_INPUT_NICKNAME);
     }
 }

--- a/src/main/java/org/festimate/team/domain/user/validator/NicknameValidator.java
+++ b/src/main/java/org/festimate/team/domain/user/validator/NicknameValidator.java
@@ -16,7 +16,7 @@ public class NicknameValidator {
     public void validate(String nickname) {
         if (!LengthValidator.rangeLengthCheck(nickname, MIN_LENGTH, MAX_LENGTH))
             throw new FestimateException(ResponseError.INVALID_INPUT_LENGTH);
-        if (!nicknamePattern.matcher(nickname).find())
+        if (!nicknamePattern.matcher(nickname).matches())
             throw new FestimateException(ResponseError.INVALID_INPUT_NICKNAME);
     }
 }

--- a/src/main/java/org/festimate/team/global/response/ResponseError.java
+++ b/src/main/java/org/festimate/team/global/response/ResponseError.java
@@ -10,7 +10,7 @@ public enum ResponseError {
     INVALID_PLATFORM_TYPE(4001, "유효하지 않은 플랫폼 타입입니다."),
     INVALID_REQUEST_PARAMETER(4002, "요청 파라미터가 잘못되었습니다."),
     INVALID_INPUT_LENGTH(4003, "입력된 글자수가 허용된 범위를 벗어났습니다."),
-    INVALID_INPUT_NICKNAME(4004, "닉네임은 한글로만 입력 가능합니다."),
+    INVALID_INPUT_NICKNAME(4004, "닉네임은 한글 혹은 영어로만 입력 가능합니다."),
     INVALID_GRANT(4005, "유효하지 않은 인가 코드입니다."),
     INVALID_DATE_TYPE(4006, "유효하지 않은 날짜 형식입니다."),
     INVALID_TIME_TYPE(4007, "유효하지 않은 시간입니다."),

--- a/src/test/java/org/festimate/team/domain/user/service/ipml/UserServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/user/service/ipml/UserServiceImplTest.java
@@ -84,16 +84,11 @@ class UserServiceImplTest {
     @DisplayName("닉네임 한글 검증 - 한글이 아닌 경우")
     void nicknameValidatorKorea() {
         // given
-        String englishNickname = "nick";
         String numberNickname = "닉123";
         String emojiNickname = "😊😊";
         String consonantVowelNickname = "현진ㄴ";
 
-        // when & then (한글이 아닌 경우 예외 발생)
-        assertThatThrownBy(() -> nicknameValidator.validate(englishNickname))
-                .isInstanceOf(FestimateException.class)
-                .hasMessageContaining(ResponseError.INVALID_INPUT_NICKNAME.getMessage());
-
+        // when & then
         assertThatThrownBy(() -> nicknameValidator.validate(numberNickname))
                 .isInstanceOf(FestimateException.class)
                 .hasMessageContaining(ResponseError.INVALID_INPUT_NICKNAME.getMessage());


### PR DESCRIPTION
## 📌 PR 제목
[fix] #135 닉네임 검증 시 한글 -> 한글, 영어로 변경

## 📌 PR 내용
- 닉네임 입력값 검증 시 기존에는 한글만 허용되도록 되어 있었으나, 사용자 범위 확장을 위해 한글 또는 영문 대소문자를 허용하도록 검증 로직을 수정했습니다.

## 🛠 작업 내용
- [ ] 닉네임 정규식 ^[가-힣]+$ → ^[가-힣a-zA-Z]+$로 수정
- [ ] matcher().find() → matches()로 수정하여 전체 문자열 기준으로 검증
- [ ] 주석 및 예외 케이스에 맞는 커스텀 예외 유지

## 🔍 관련 이슈
Closes #135 

## 📸 스크린샷 (Optional)

## 📚 레퍼런스 (Optional)
- 정규표현식 테스트: https://regex101.com/
- 영문 및 한글 유효성 검사 참고 자료: [위키백과 - 유니코드 한글](https://ko.wikipedia.org/wiki/%ED%95%9C%EA%B8%80_%EC%9C%A0%EB%8B%88%EC%BD%94%EB%93%9C)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Nicknames can now include both Korean and English letters, expanding the allowed character set.

- **Bug Fixes**
  - Updated error messages to accurately reflect the new nickname requirements, ensuring users receive correct guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->