### PR TITLE
[feat] #139 페스티벌 공동 호스트 추가 API 구현

### DIFF
--- a/src/main/java/org/festimate/team/api/admin/AdminController.java
+++ b/src/main/java/org/festimate/team/api/admin/AdminController.java
@@ -2,10 +2,7 @@ package org.festimate.team.api.admin;
 
 import lombok.RequiredArgsConstructor;
 import org.festimate.team.api.admin.dto.*;
-import org.festimate.team.api.facade.FestivalFacade;
-import org.festimate.team.api.facade.MatchingFacade;
-import org.festimate.team.api.facade.ParticipantFacade;
-import org.festimate.team.api.facade.PointFacade;
+import org.festimate.team.api.facade.*;
 import org.festimate.team.api.point.dto.PointHistoryResponse;
 import org.festimate.team.global.response.ApiResponse;
 import org.festimate.team.global.response.ResponseBuilder;
@@ -21,6 +18,7 @@ import java.util.List;
 public class AdminController {
     private final JwtService jwtService;
     private final FestivalFacade festivalFacade;
+    private final FestivalHostFacade festivalHostFacade;
     private final ParticipantFacade participantFacade;
     private final PointFacade pointFacade;
     private final MatchingFacade matchingFacade;
@@ -75,6 +73,17 @@ public class AdminController {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
         pointFacade.rechargePoints(userId, festivalId, request);
         return ResponseBuilder.ok(null);
+    }
+
+    @PostMapping("/{festivalId}/hosts")
+    public ResponseEntity<ApiResponse<Void>> addHost(
+            @RequestHeader("Authorization") String accessToken,
+            @PathVariable("festivalId") Long festivalId,
+            @RequestBody AddHostRequest request
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        festivalHostFacade.addHost(userId, festivalId, request);
+        return ResponseBuilder.created(null);
     }
 
     @GetMapping("/{festivalId}/participants/{participantId}/points")

--- a/src/main/java/org/festimate/team/api/admin/dto/AddHostRequest.java
+++ b/src/main/java/org/festimate/team/api/admin/dto/AddHostRequest.java
@@ -1,0 +1,6 @@
+package org.festimate.team.api.admin.dto;
+
+public record AddHostRequest(
+        long participantId
+) {
+}

--- a/src/main/java/org/festimate/team/api/facade/FestivalHostFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/FestivalHostFacade.java
@@ -1,0 +1,33 @@
+package org.festimate.team.api.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.festimate.team.api.admin.dto.AddHostRequest;
+import org.festimate.team.domain.festival.entity.Festival;
+import org.festimate.team.domain.festival.service.FestivalService;
+import org.festimate.team.domain.festivalHost.service.FestivalHostService;
+import org.festimate.team.domain.participant.entity.Participant;
+import org.festimate.team.domain.participant.service.ParticipantService;
+import org.festimate.team.domain.user.entity.User;
+import org.festimate.team.domain.user.service.UserService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class FestivalHostFacade {
+    private final UserService userService;
+    private final FestivalService festivalService;
+    private final FestivalHostService festivalHostService;
+    private final ParticipantService participantService;
+
+    @Transactional
+    public void addHost(Long userId, Long festivalId, AddHostRequest request) {
+        User host = userService.getUserByIdOrThrow(userId);
+        Festival festival = festivalService.getFestivalByIdOrThrow(festivalId);
+        festivalService.isHost(host, festival);
+
+        Participant participant = participantService.getParticipantById(request.participantId());
+        User newHost = participant.getUser();
+        festivalHostService.addHost(newHost, festival);
+    }
+}

--- a/src/main/java/org/festimate/team/domain/festival/entity/Festival.java
+++ b/src/main/java/org/festimate/team/domain/festival/entity/Festival.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.festimate.team.domain.festivalHost.entity.FestivalHost;
 import org.festimate.team.domain.matching.entity.Matching;
 import org.festimate.team.domain.participant.entity.Participant;
 import org.festimate.team.domain.user.entity.User;

--- a/src/main/java/org/festimate/team/domain/festivalHost/entity/FestivalHost.java
+++ b/src/main/java/org/festimate/team/domain/festivalHost/entity/FestivalHost.java
@@ -1,10 +1,11 @@
-package org.festimate.team.domain.festival.entity;
+package org.festimate.team.domain.festivalHost.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.user.entity.User;
 
 import java.time.LocalDateTime;

--- a/src/main/java/org/festimate/team/domain/festivalHost/repository/FestivalHostRepository.java
+++ b/src/main/java/org/festimate/team/domain/festivalHost/repository/FestivalHostRepository.java
@@ -1,0 +1,8 @@
+package org.festimate.team.domain.festivalHost.repository;
+
+import org.festimate.team.domain.festivalHost.entity.FestivalHost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FestivalHostRepository extends JpaRepository<FestivalHost, Long> {
+
+}

--- a/src/main/java/org/festimate/team/domain/festivalHost/service/FestivalHostService.java
+++ b/src/main/java/org/festimate/team/domain/festivalHost/service/FestivalHostService.java
@@ -1,0 +1,10 @@
+package org.festimate.team.domain.festivalHost.service;
+
+import org.festimate.team.domain.festival.entity.Festival;
+import org.festimate.team.domain.user.entity.User;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface FestivalHostService {
+    @Transactional
+    void addHost(User newHost, Festival festival);
+}

--- a/src/main/java/org/festimate/team/domain/festivalHost/service/impl/FestivalHostServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/festivalHost/service/impl/FestivalHostServiceImpl.java
@@ -1,0 +1,30 @@
+package org.festimate.team.domain.festivalHost.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.festimate.team.domain.festival.entity.Festival;
+import org.festimate.team.domain.festivalHost.entity.FestivalHost;
+import org.festimate.team.domain.festivalHost.repository.FestivalHostRepository;
+import org.festimate.team.domain.festivalHost.service.FestivalHostService;
+import org.festimate.team.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FestivalHostServiceImpl implements FestivalHostService {
+
+    private final FestivalHostRepository festivalHostRepository;
+
+    @Transactional
+    @Override
+    public void addHost(User newHost, Festival festival) {
+        FestivalHost newFestivalHost = FestivalHost.builder()
+                .festival(festival)
+                .host(newHost)
+                .build();
+
+        festivalHostRepository.save(newFestivalHost);
+    }
+}

--- a/src/test/java/org/festimate/team/common/mock/MockFactory.java
+++ b/src/test/java/org/festimate/team/common/mock/MockFactory.java
@@ -2,7 +2,7 @@ package org.festimate.team.common.mock;
 
 import org.festimate.team.domain.festival.entity.Category;
 import org.festimate.team.domain.festival.entity.Festival;
-import org.festimate.team.domain.festival.entity.FestivalHost;
+import org.festimate.team.domain.festivalHost.entity.FestivalHost;
 import org.festimate.team.domain.participant.entity.Participant;
 import org.festimate.team.domain.participant.entity.TypeResult;
 import org.festimate.team.domain.user.entity.*;


### PR DESCRIPTION
## 📌 PR 제목
[feat] #139 페스티벌 공동 호스트 추가 API 구현

## 📌 PR 내용
- 페스티벌 생성자가 특정 참가자를 공동 호스트로 추가할 수 있는 API를 구현했습니다.
- 기존 호스트 여부를 검증한 뒤, 해당 참가자의 유저 정보를 기반으로 FestivalHost 엔티티를 생성합니다.

## 🛠 작업 내용
- [x] FestivalHostFacade.addHost() 메서드 구현
- [x] 유저, 페스티벌, 참가자 조회 및 검증 로직 추가
- [x] FestivalHostService.addHost() 도메인 로직 구현
- [x] DB에 새로운 공동 호스트 정보 저장

## 🔍 관련 이슈
Closes #139 

## 📸 스크린샷 (Optional)
<img width="653" alt="image" src="https://github.com/user-attachments/assets/b0d92d8b-6079-4dc6-8061-6999ca7bd438" />

## 📚 레퍼런스 (Optional)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new POST endpoint for administrators to assign hosts to festivals.
  - Introduced support for managing festival hosts, allowing administrators to add a participant as a host to a festival.

- **Bug Fixes**
  - None.

- **Documentation**
  - None.

- **Refactor**
  - Internal restructuring of entity and repository packages related to festival hosts (no impact on user experience).

- **Tests**
  - None.

- **Chores**
  - None.

- **Revert**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->