### PR TITLE
[hotfix] #143 매칭 상세조회 시 본인 소유 매칭만 조회 가능하도록 검증 로직 추가

### DIFF
--- a/src/main/java/org/festimate/team/domain/matching/validator/MatchingValidator.java
+++ b/src/main/java/org/festimate/team/domain/matching/validator/MatchingValidator.java
@@ -1,6 +1,5 @@
 package org.festimate.team.domain.matching.validator;
 
-import lombok.extern.slf4j.Slf4j;
 import org.festimate.team.domain.festival.entity.Festival;
 import org.festimate.team.domain.matching.entity.Matching;
 import org.festimate.team.domain.participant.entity.Participant;
@@ -11,22 +10,16 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDateTime;
 
 @Component
-@Slf4j
 public class MatchingValidator {
 
     public static void isMatchingDateValid(final LocalDateTime requestMatchingTime, final LocalDateTime matchingStartAt) {
-        log.info("Validating requestMatchingTime. requestMatchingTime={}, matchingStartAt={}", requestMatchingTime, matchingStartAt);
-
         if (requestMatchingTime.isBefore(matchingStartAt)) {
-            log.warn("Invalid requestMatchingTime: requestMatchingTime is before festival matchingStartAt");
             throw new FestimateException(ResponseError.INVALID_TIME_TYPE);
         }
-
-        log.info("matchingStartAt is valid.");
     }
 
     public static void isApplicantParticipantValid(final Matching matching, final Participant participant) {
-        if (matching.getApplicantParticipant() != participant) {
+        if (!matching.getApplicantParticipant().equals(participant)) {
             throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
         }
     }

--- a/src/main/java/org/festimate/team/domain/matching/validator/MatchingValidator.java
+++ b/src/main/java/org/festimate/team/domain/matching/validator/MatchingValidator.java
@@ -1,8 +1,11 @@
 package org.festimate.team.domain.matching.validator;
 
 import lombok.extern.slf4j.Slf4j;
-import org.festimate.team.global.response.ResponseError;
+import org.festimate.team.domain.festival.entity.Festival;
+import org.festimate.team.domain.matching.entity.Matching;
+import org.festimate.team.domain.participant.entity.Participant;
 import org.festimate.team.global.exception.FestimateException;
+import org.festimate.team.global.response.ResponseError;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -20,5 +23,17 @@ public class MatchingValidator {
         }
 
         log.info("matchingStartAt is valid.");
+    }
+
+    public static void isApplicantParticipantValid(final Matching matching, final Participant participant) {
+        if (matching.getApplicantParticipant() != participant) {
+            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
+        }
+    }
+
+    public static void isFestivalMatchValid(final Matching matching, final Festival festival) {
+        if (!matching.getFestival().getFestivalId().equals(festival.getFestivalId())) {
+            throw new FestimateException(ResponseError.FORBIDDEN_RESOURCE);
+        }
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
[hotfix] #143 매칭 상세조회 시 본인 소유 매칭만 조회 가능하도록 검증 로직 추가

## 📌 PR 내용
- 매칭 상세조회 API에서 로그인 사용자가 자신의 매칭이 아닌 다른 사람의 매칭을 URL 조작으로 조회할 수 있는 문제를 수정했습니다.
- 이를 위해 MatchingValidator에 검증 로직을 추가하고, 해당 로직을 서비스 로직에서 호출하도록 리팩토링했습니다.
- 검증 로직이 잘 동작하는지 확인하는 테스트 코드도 함께 작성했습니다.

## 🛠 작업 내용
- [x] 본인 소유의 매칭만 조회할 수 있도록 검증 로직 추가
- [x] MatchingValidator에 책임 분리 및 리팩토링
- [x] 검증 실패 시 예외 발생 테스트 코드 작성

## 🔍 관련 이슈
Closes #143 

## 📸 스크린샷 (Optional)
<img width="704" alt="image" src="https://github.com/user-attachments/assets/4f9d54bc-fd13-4e0b-aba4-b812792f0419" />

## 📚 레퍼런스 (Optional)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced validation to confirm participant and festival consistency when accessing matching details.
- **Tests**
	- Added a test to verify that unauthorized access to matching details is correctly blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->