### PR TITLE
[feat] #145 매칭 후보 조회 로직에 QueryDSL 도입 및 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-    ext {
-        queryDslVersion = "5.0.0"
-    }
-}
-
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.3'
@@ -66,8 +60,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'  // JUnit 테스트 실행기
 
     // --- QueryDSL ---
-    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
-    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 
     // --- Jakarta Persistence API ---
     implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,16 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.3'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'org.festiamte'
+group = 'org.festimate'
 version = '0.0.1-SNAPSHOT'
 
 java {
@@ -58,6 +64,24 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'  // WebFlux 테스트 지원
     testImplementation 'org.springframework.security:spring-security-test'  // Security 테스트 지원
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'  // JUnit 테스트 실행기
+
+    // --- QueryDSL ---
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+
+    // --- Jakarta Persistence API ---
+    implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src/main/java'
+            // Q-타입 생성 위치를 IDE가 인식하도록 추가
+            srcDir 'build/generated/sources/annotationProcessor/java/main'
+        }
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface MatchingRepository extends JpaRepository<Matching, Long> {
+public interface MatchingRepository extends JpaRepository<Matching, Long>, MatchingRepositoryCustom {
     @Query("""
                 SELECT p FROM Participant p
                 JOIN FETCH p.user

--- a/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepository.java
@@ -14,33 +14,6 @@ import java.util.Optional;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long>, MatchingRepositoryCustom {
     @Query("""
-                SELECT p FROM Participant p
-                JOIN FETCH p.user
-                LEFT JOIN Matching m1
-                       ON (m1.applicantParticipant = p OR m1.targetParticipant = p)
-                WHERE p.festival.festivalId = :festivalId
-                  AND p.typeResult = :typeResult
-                  AND p.user.gender != :gender
-                  AND p.participantId != :participantId
-                  AND p.participantId NOT IN (
-                      SELECT m.targetParticipant.participantId
-                      FROM Matching m
-                      WHERE m.applicantParticipant.participantId = :participantId
-                        AND m.status = 'COMPLETED'
-                  )
-                GROUP BY p
-                ORDER BY COUNT(m1) ASC
-            """)
-    List<Participant> findMatchingCandidates(
-            @Param("participantId") Long participantId,
-            @Param("typeResult") TypeResult typeResult,
-            @Param("gender") Gender gender,
-            @Param("festivalId") Long festivalId,
-            Pageable pageable
-    );
-
-
-    @Query("""
                 SELECT m FROM Matching m
                 WHERE m.festival.festivalId = :festivalId
                   AND m.status = 'PENDING'

--- a/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepositoryCustom.java
+++ b/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepositoryCustom.java
@@ -1,0 +1,21 @@
+package org.festimate.team.domain.matching.repository;
+
+import org.festimate.team.domain.participant.entity.Participant;
+import org.festimate.team.domain.participant.entity.TypeResult;
+import org.festimate.team.domain.user.entity.Gender;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface MatchingRepositoryCustom {
+    /**
+     * QueryDSL로 매칭 후보를 동적으로 조회
+     */
+    List<Participant> findMatchingCandidatesDsl(
+            Long applicantId,
+            TypeResult typeResult,
+            Gender gender,
+            Long festivalId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepositoryCustom.java
+++ b/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepositoryCustom.java
@@ -8,14 +8,14 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface MatchingRepositoryCustom {
-    /**
-     * QueryDSL로 매칭 후보를 동적으로 조회
-     */
+    List<Long> findExcludeIds(Long applicantId);
+
     List<Participant> findMatchingCandidatesDsl(
             Long applicantId,
             TypeResult typeResult,
             Gender gender,
             Long festivalId,
-            Pageable pageable
+            Pageable pageable,
+            List<Long> excludedIds
     );
 }

--- a/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepositoryImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepositoryImpl.java
@@ -1,0 +1,61 @@
+package org.festimate.team.domain.matching.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.festimate.team.domain.matching.entity.MatchingStatus;
+import org.festimate.team.domain.matching.entity.QMatching;
+import org.festimate.team.domain.participant.entity.Participant;
+import org.festimate.team.domain.participant.entity.QParticipant;
+import org.festimate.team.domain.participant.entity.TypeResult;
+import org.festimate.team.domain.user.entity.Gender;
+import org.festimate.team.domain.user.entity.QUser;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QParticipant p = QParticipant.participant;
+    private final QMatching m = QMatching.matching;
+    private final QMatching mSub = new QMatching("mSub");
+    private final QUser u = QUser.user;
+
+    @Override
+    public List<Participant> findMatchingCandidatesDsl(
+            Long applicantId,
+            TypeResult typeResult,
+            Gender gender,
+            Long festivalId,
+            Pageable pageable
+    ) {
+        List<Long> excludedIds = queryFactory
+                .select(mSub.targetParticipant.participantId)
+                .from(mSub)
+                .where(
+                        mSub.applicantParticipant.participantId.eq(applicantId)
+                                .and(mSub.status.eq(MatchingStatus.COMPLETED))
+                )
+                .fetch();
+
+        return queryFactory
+                .selectFrom(p)
+                .join(p.user, u).fetchJoin()
+                .leftJoin(m)
+                .on(m.applicantParticipant.eq(p).or(m.targetParticipant.eq(p)))
+                .where(
+                        p.festival.festivalId.eq(festivalId),
+                        p.typeResult.eq(typeResult),
+                        u.gender.ne(gender),
+                        p.participantId.ne(applicantId),
+                        excludedIds.isEmpty() ? null : p.participantId.notIn(excludedIds)
+                )
+                .groupBy(p)
+                .orderBy(m.count().asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+}

--- a/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepositoryImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/repository/MatchingRepositoryImpl.java
@@ -24,14 +24,8 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
     private final QUser u = QUser.user;
 
     @Override
-    public List<Participant> findMatchingCandidatesDsl(
-            Long applicantId,
-            TypeResult typeResult,
-            Gender gender,
-            Long festivalId,
-            Pageable pageable
-    ) {
-        List<Long> excludedIds = queryFactory
+    public List<Long> findExcludeIds(Long applicantId) {
+        return queryFactory
                 .select(mSub.targetParticipant.participantId)
                 .from(mSub)
                 .where(
@@ -39,7 +33,17 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
                                 .and(mSub.status.eq(MatchingStatus.COMPLETED))
                 )
                 .fetch();
+    }
 
+    @Override
+    public List<Participant> findMatchingCandidatesDsl(
+            Long applicantId,
+            TypeResult typeResult,
+            Gender gender,
+            Long festivalId,
+            Pageable pageable,
+            List<Long> excludedIds
+    ) {
         return queryFactory
                 .selectFrom(p)
                 .join(p.user, u).fetchJoin()

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -90,6 +90,7 @@ public class MatchingServiceImpl implements MatchingService {
     @Transactional
     @Override
     public Optional<Participant> findBestCandidateByPriority(long festivalId, Participant participant) {
+        List<Long> excludedIds = matchingRepository.findExcludeIds(participant.getParticipantId());
         List<TypeResult> priorities = MATCHING_PRIORITIES.get(participant.getTypeResult());
         Gender myGender = participant.getUser().getGender();
 
@@ -99,7 +100,8 @@ public class MatchingServiceImpl implements MatchingService {
                     priorityType,
                     myGender,
                     festivalId,
-                    PageRequest.of(0, 1)
+                    PageRequest.of(0, 1),
+                    excludedIds
             ).stream().findFirst();
 
             if (candidate.isPresent()) {

--- a/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImpl.java
@@ -94,7 +94,7 @@ public class MatchingServiceImpl implements MatchingService {
         Gender myGender = participant.getUser().getGender();
 
         for (TypeResult priorityType : priorities) {
-            Optional<Participant> candidate = matchingRepository.findMatchingCandidates(
+            Optional<Participant> candidate = matchingRepository.findMatchingCandidatesDsl(
                     participant.getParticipantId(),
                     priorityType,
                     myGender,

--- a/src/main/java/org/festimate/team/infra/config/QuerydslConfig.java
+++ b/src/main/java/org/festimate/team/infra/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package org.festimate.team.infra.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    public EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/org/festimate/team/infra/config/QuerydslConfig.java
+++ b/src/main/java/org/festimate/team/infra/config/QuerydslConfig.java
@@ -2,17 +2,13 @@ package org.festimate.team.infra.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class QuerydslConfig {
-    @PersistenceContext
-    public EntityManager em;
-
     @Bean
-    public JPAQueryFactory jpaQueryFactory() {
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
         return new JPAQueryFactory(em);
     }
 }

--- a/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
@@ -123,7 +123,7 @@ class MatchingServiceImplTest {
                 .festival(festival)
                 .build();
 
-        when(matchingRepository.findMatchingCandidates(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
                 .thenReturn(List.of(target));
 
         var result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
@@ -147,7 +147,7 @@ class MatchingServiceImplTest {
         ReflectionTestUtils.setField(applicant, "participantId", 1L);
 
         // 1순위 PHOTO에 대상 없음
-        when(matchingRepository.findMatchingCandidates(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
                 .thenReturn(Collections.emptyList());
 
         // 2순위 INFLUENCER에 대상 있음
@@ -157,7 +157,7 @@ class MatchingServiceImplTest {
                 .festival(festival)
                 .build();
 
-        when(matchingRepository.findMatchingCandidates(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
                 .thenReturn(List.of(secondPriorityCandidate));
 
         var result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
@@ -180,12 +180,12 @@ class MatchingServiceImplTest {
         Participant thirdPriorityCandidate = mockParticipant(thirdPriorityUser, festival, TypeResult.NEWBIE, 2L);
 
         // 1순위 PHOTO, 2순위 INFLUENCER 대상 없음
-        when(matchingRepository.findMatchingCandidates(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
                 .thenReturn(Collections.emptyList());
-        when(matchingRepository.findMatchingCandidates(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
                 .thenReturn(Collections.emptyList());
         // 3순위 대상 있음
-        when(matchingRepository.findMatchingCandidates(1L, TypeResult.NEWBIE, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.NEWBIE, Gender.MAN, 1L, PageRequest.of(0, 1)))
                 .thenReturn(List.of(thirdPriorityCandidate));
 
         var result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
@@ -208,11 +208,11 @@ class MatchingServiceImplTest {
         ReflectionTestUtils.setField(applicant, "participantId", 1L);
 
         // 대상이 존재하나 이미 매칭됨 (Repository에서 필터링 됨)
-        when(matchingRepository.findMatchingCandidates(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
                 .thenReturn(Collections.emptyList());
-        when(matchingRepository.findMatchingCandidates(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
                 .thenReturn(Collections.emptyList());
-        when(matchingRepository.findMatchingCandidates(1L, TypeResult.NEWBIE, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.NEWBIE, Gender.MAN, 1L, PageRequest.of(0, 1)))
                 .thenReturn(Collections.emptyList());
 
         Optional<Participant> result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
@@ -232,7 +232,7 @@ class MatchingServiceImplTest {
                 .festival(festival)
                 .build();
 
-        when(matchingRepository.findMatchingCandidates(
+        when(matchingRepository.findMatchingCandidatesDsl(
                 applicant.getParticipantId(), TypeResult.PHOTO, Gender.MAN, festival.getFestivalId(), PageRequest.of(0, 1)
         )).thenReturn(Collections.emptyList());
 
@@ -376,7 +376,7 @@ class MatchingServiceImplTest {
         Participant p2 = mockParticipant(candidate2, festival, TypeResult.PHOTO, 3L);
 
         // 후보 2명 반환
-        when(matchingRepository.findMatchingCandidates(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
                 .thenReturn(List.of(p1, p2));
 
         // when

--- a/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
+++ b/src/test/java/org/festimate/team/domain/matching/service/impl/MatchingServiceImplTest.java
@@ -116,6 +116,7 @@ class MatchingServiceImplTest {
                 .festival(festival)
                 .build();
         ReflectionTestUtils.setField(applicant, "participantId", 1L);
+        List<Long> excludedIds = matchingRepository.findExcludeIds(applicant.getParticipantId());
 
         Participant target = Participant.builder()
                 .user(targetUser)
@@ -123,7 +124,7 @@ class MatchingServiceImplTest {
                 .festival(festival)
                 .build();
 
-        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1), excludedIds))
                 .thenReturn(List.of(target));
 
         var result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
@@ -145,9 +146,10 @@ class MatchingServiceImplTest {
                 .festival(festival)
                 .build();
         ReflectionTestUtils.setField(applicant, "participantId", 1L);
+        List<Long> excludedIds = matchingRepository.findExcludeIds(applicant.getParticipantId());
 
         // 1순위 PHOTO에 대상 없음
-        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1), excludedIds))
                 .thenReturn(Collections.emptyList());
 
         // 2순위 INFLUENCER에 대상 있음
@@ -157,7 +159,7 @@ class MatchingServiceImplTest {
                 .festival(festival)
                 .build();
 
-        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1), excludedIds))
                 .thenReturn(List.of(secondPriorityCandidate));
 
         var result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
@@ -176,16 +178,18 @@ class MatchingServiceImplTest {
 
         // 신청자
         Participant applicant = mockParticipant(applicantUser, festival, TypeResult.INFLUENCER, 1L);
+        List<Long> excludedIds = matchingRepository.findExcludeIds(applicant.getParticipantId());
+
         // 3순위 NEWBIE에 대상 있음
         Participant thirdPriorityCandidate = mockParticipant(thirdPriorityUser, festival, TypeResult.NEWBIE, 2L);
 
         // 1순위 PHOTO, 2순위 INFLUENCER 대상 없음
-        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1), excludedIds))
                 .thenReturn(Collections.emptyList());
-        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1), excludedIds))
                 .thenReturn(Collections.emptyList());
         // 3순위 대상 있음
-        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.NEWBIE, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.NEWBIE, Gender.MAN, 1L, PageRequest.of(0, 1), excludedIds))
                 .thenReturn(List.of(thirdPriorityCandidate));
 
         var result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
@@ -206,13 +210,14 @@ class MatchingServiceImplTest {
                 .festival(festival)
                 .build();
         ReflectionTestUtils.setField(applicant, "participantId", 1L);
+        List<Long> excludedIds = matchingRepository.findExcludeIds(applicant.getParticipantId());
 
         // 대상이 존재하나 이미 매칭됨 (Repository에서 필터링 됨)
-        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1), excludedIds))
                 .thenReturn(Collections.emptyList());
-        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.INFLUENCER, Gender.MAN, 1L, PageRequest.of(0, 1), excludedIds))
                 .thenReturn(Collections.emptyList());
-        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.NEWBIE, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.NEWBIE, Gender.MAN, 1L, PageRequest.of(0, 1), excludedIds))
                 .thenReturn(Collections.emptyList());
 
         Optional<Participant> result = matchingService.findBestCandidateByPriority(festival.getFestivalId(), applicant);
@@ -231,9 +236,10 @@ class MatchingServiceImplTest {
                 .typeResult(TypeResult.INFLUENCER)
                 .festival(festival)
                 .build();
+        List<Long> excludedIds = matchingRepository.findExcludeIds(applicant.getParticipantId());
 
         when(matchingRepository.findMatchingCandidatesDsl(
-                applicant.getParticipantId(), TypeResult.PHOTO, Gender.MAN, festival.getFestivalId(), PageRequest.of(0, 1)
+                applicant.getParticipantId(), TypeResult.PHOTO, Gender.MAN, festival.getFestivalId(), PageRequest.of(0, 1), excludedIds
         )).thenReturn(Collections.emptyList());
 
         Optional<Participant> result = matchingService.findBestCandidateByPriority(
@@ -369,6 +375,7 @@ class MatchingServiceImplTest {
         User applicantUser = mockUser("신청자", Gender.MAN, 1L);
         Festival festival = mockFestival(applicantUser, 1L, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
         Participant applicant = mockParticipant(applicantUser, festival, TypeResult.INFLUENCER, 1L);
+        List<Long> excludedIds = matchingRepository.findExcludeIds(applicant.getParticipantId());
 
         User candidate1 = mockUser("후보1", Gender.WOMAN, 2L);
         User candidate2 = mockUser("후보2", Gender.WOMAN, 3L);
@@ -376,7 +383,7 @@ class MatchingServiceImplTest {
         Participant p2 = mockParticipant(candidate2, festival, TypeResult.PHOTO, 3L);
 
         // 후보 2명 반환
-        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1)))
+        when(matchingRepository.findMatchingCandidatesDsl(1L, TypeResult.PHOTO, Gender.MAN, 1L, PageRequest.of(0, 1), excludedIds))
                 .thenReturn(List.of(p1, p2));
 
         // when


### PR DESCRIPTION
## 📌 PR 제목
[feat] #145 매칭 후보 조회 로직에 QueryDSL 도입 및 최적화

## 📌 PR 내용
- `QueryDSL` 도입: 기존 `JPQL` 문자열 기반 쿼리를 `QueryDSL` 메서드 체이닝으로 전환하여 동적 필터링, 조건 조합 편의성 확보
- 서브쿼리 캐싱: `findBestCandidateByPriority` 호출 시 매번 실행되던 `이미 매칭된 대상 조회` 서브쿼리를 서비스 레벨에서 한 번만 실행하도록 변경해 불필요한 DB 호출을 절감

## 🛠 작업 내용
- [x] QueryDSL 기반 MatchingRepositoryImpl 구현
- [x] Q-타입(QParticipant, QMatching, QUser) 활용한 동적 쿼리 작성
- [x] .where(...) 체이닝으로 null 조건 자동 무시
- [x] MatchingServiceImpl에 QueryDSL 도입 로직 반영
- [x] MatchingRepository에 findExcludeIds(Long applicantId) 메서드 추가: 서브쿼리 캐싱
- [x] findMatchingCandidatesDsl 시그니처 수정: List<Long> excludedIds 파라미터 추가
- [x] findBestCandidateByPriority 내부에서 excludedIds를 한 번만 조회하도록 리팩토링

## 🔍 관련 이슈
Closes #145 

## 📸 스크린샷 (Optional)
<img width="631" alt="image" src="https://github.com/user-attachments/assets/ff0b7204-efaa-4dc8-a3dd-47e5fb7fe000" />

## 📚 레퍼런스 (Optional)
https://reprisal.tistory.com/178
https://adjh54.tistory.com/484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved participant matching logic to exclude previously matched candidates, enhancing the accuracy of match suggestions.
  - Added support for more advanced and efficient matching queries using QueryDSL.

- **Chores**
  - Updated build configuration to support QueryDSL and annotation processing for better query handling.

- **Bug Fixes**
  - Corrected a typo in the project group identifier.

- **Tests**
  - Updated tests to reflect changes in matching logic and candidate exclusion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->