### PR TITLE
[feat] #147 페스티벌 입장 시 자동으로 포인트 충전하는 기능 구현

### DIFF
--- a/src/main/java/org/festimate/team/api/facade/ParticipantFacade.java
+++ b/src/main/java/org/festimate/team/api/facade/ParticipantFacade.java
@@ -42,6 +42,7 @@ public class ParticipantFacade {
             throw new FestimateException(ResponseError.PARTICIPANT_ALREADY_EXISTS);
         }
         Participant participant = participantService.createParticipant(user, festival, request);
+        pointService.rechargePoint(participant, 10);
         matchingService.matchPendingParticipants(participant);
 
         return EntryResponse.of(participant);

--- a/src/test/java/org/festimate/team/api/facade/ParticipantFacadeTest.java
+++ b/src/test/java/org/festimate/team/api/facade/ParticipantFacadeTest.java
@@ -82,6 +82,24 @@ class ParticipantFacadeTest {
     }
 
     @Test
+    @DisplayName("참가자 생성 시 10포인트가 충전된다")
+    void createParticipant_success_point() {
+        when(userService.getUserByIdOrThrow(1L)).thenReturn(user);
+        when(festivalService.getFestivalByIdOrThrow(1L)).thenReturn(festival);
+        when(participantService.getParticipant(user, festival)).thenReturn(null);
+        when(participantService.createParticipant(any(), any(), any())).thenReturn(participant);
+
+        var response = participantFacade.createParticipant(1L, 1L, null);
+
+        // then
+        assertThat(response.participantId()).isNotNull();
+        // 포인트 충전 메서드 호출 여부 검증
+        verify(pointService).rechargePoint(participant, 10);
+        // 매칭 메서드 호출 여부 검증
+        verify(matchingService).matchPendingParticipants(participant);
+    }
+
+    @Test
     @DisplayName("내 프로필 조회 성공")
     void getParticipantProfile_success() {
         when(userService.getUserByIdOrThrow(1L)).thenReturn(user);


### PR DESCRIPTION
## 📌 PR 제목
[feat] #147 페스티벌 입장 시 자동으로 포인트 충전하는 기능 구현

## 📌 PR 내용
- 페스티벌 입장 시 자동으로 포인트 충전하는 기능 구현

## 🛠 작업 내용
- [ ] 페스티벌 입장 시 자동으로 10포인트를 충전할 수 있도록 구현하였습니다.

## 🔍 관련 이슈
Closes #147 

## 📸 스크린샷 (Optional)
<img width="702" alt="image" src="https://github.com/user-attachments/assets/7f31f727-3b91-422c-88ab-99ec6dee2d61" />

## 📚 레퍼런스 (Optional)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly created participants now automatically receive 10 points upon creation.

* **Tests**
  * Added a test to verify that participants are granted 10 points when created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->