### PR TITLE
[refactor] #150 builder 메서드 접근제어자 public -> private 변경

### DIFF
--- a/src/main/java/org/festimate/team/api/auth/dto/TokenResponse.java
+++ b/src/main/java/org/festimate/team/api/auth/dto/TokenResponse.java
@@ -1,8 +1,9 @@
 package org.festimate.team.api.auth.dto;
 
-public record TokenResponse(Long userId,
-                            String accessToken,
-                            String refreshToken
+public record TokenResponse(
+        Long userId,
+        String accessToken,
+        String refreshToken
 ) {
     public static TokenResponse of(Long userId, String accessToken, String refreshToken) {
         return new TokenResponse(userId, accessToken, refreshToken);

--- a/src/main/java/org/festimate/team/api/user/dto/SignUpRequest.java
+++ b/src/main/java/org/festimate/team/api/user/dto/SignUpRequest.java
@@ -5,14 +5,15 @@ import org.festimate.team.domain.user.entity.Gender;
 import org.festimate.team.domain.user.entity.Mbti;
 import org.festimate.team.domain.user.entity.Platform;
 
-public record SignUpRequest(String name,
-                            String phoneNumber,
-                            String nickName,
-                            int birthYear,
-                            Gender gender,
-                            Mbti mbti,
-                            AppearanceType appearanceType,
-                            Platform platform
+public record SignUpRequest(
+        String name,
+        String phoneNumber,
+        String nickName,
+        int birthYear,
+        Gender gender,
+        Mbti mbti,
+        AppearanceType appearanceType,
+        Platform platform
 ) {
     public static SignUpRequest toUserSignUp(SignUpRequest request) {
         return new SignUpRequest(

--- a/src/main/java/org/festimate/team/domain/festival/entity/Festival.java
+++ b/src/main/java/org/festimate/team/domain/festival/entity/Festival.java
@@ -57,7 +57,7 @@ public class Festival extends BaseTimeEntity {
     private List<Matching> matchings;
 
     @Builder
-    public Festival(String title, Category category, LocalDate startDate, LocalDate endDate, LocalDateTime matchingStartAt, String inviteCode) {
+    private Festival(String title, Category category, LocalDate startDate, LocalDate endDate, LocalDateTime matchingStartAt, String inviteCode) {
         this.title = title;
         this.category = category;
         this.startDate = startDate;

--- a/src/main/java/org/festimate/team/domain/festivalHost/entity/FestivalHost.java
+++ b/src/main/java/org/festimate/team/domain/festivalHost/entity/FestivalHost.java
@@ -41,7 +41,7 @@ public class FestivalHost {
     private LocalDateTime addedAt;
 
     @Builder
-    public FestivalHost(Festival festival, User host) {
+    private FestivalHost(Festival festival, User host) {
         this.festival = festival;
         this.host = host;
         this.addedAt = LocalDateTime.now();

--- a/src/main/java/org/festimate/team/domain/matching/entity/Matching.java
+++ b/src/main/java/org/festimate/team/domain/matching/entity/Matching.java
@@ -43,7 +43,7 @@ public class Matching extends BaseTimeEntity {
     private LocalDateTime matchDate;
 
     @Builder
-    public Matching(Festival festival, Participant applicantParticipant, Participant targetParticipant,
+    private Matching(Festival festival, Participant applicantParticipant, Participant targetParticipant,
                     MatchingStatus status, LocalDateTime matchDate) {
         this.festival = festival;
         this.applicantParticipant = applicantParticipant;

--- a/src/main/java/org/festimate/team/domain/participant/entity/Participant.java
+++ b/src/main/java/org/festimate/team/domain/participant/entity/Participant.java
@@ -52,7 +52,7 @@ public class Participant extends BaseTimeEntity {
     private List<Matching> matchingsAsTarget;
 
     @Builder
-    public Participant(User user, Festival festival, TypeResult typeResult, String introduction, String message) {
+    private Participant(User user, Festival festival, TypeResult typeResult, String introduction, String message) {
         this.user = user;
         this.festival = festival;
         this.typeResult = typeResult;

--- a/src/main/java/org/festimate/team/domain/point/entity/Point.java
+++ b/src/main/java/org/festimate/team/domain/point/entity/Point.java
@@ -32,7 +32,7 @@ public class Point extends BaseTimeEntity {
     private TransactionType transactionType;
 
     @Builder
-    public Point(Participant participant, Integer point, TransactionType transactionType) {
+    private Point(Participant participant, Integer point, TransactionType transactionType) {
         this.participant = participant;
         this.point = point;
         this.transactionType = transactionType;

--- a/src/main/java/org/festimate/team/domain/user/entity/User.java
+++ b/src/main/java/org/festimate/team/domain/user/entity/User.java
@@ -53,7 +53,7 @@ public class User extends BaseTimeEntity {
     private String refreshToken;
 
     @Builder
-    public User(String name, String phoneNumber, String nickname, Integer birthYear, Gender gender, Mbti mbti,
+    private User(String name, String phoneNumber, String nickname, Integer birthYear, Gender gender, Mbti mbti,
                 AppearanceType appearanceType, String platformId, Platform platform, String refreshToken) {
         this.name = name;
         this.phoneNumber = phoneNumber;


### PR DESCRIPTION
## 📌 PR 제목
[refactor] #150 builder 메서드 접근제어자 public -> private 변경

## 📌 PR 내용
- 객체 생성 방식을 통제하기 위해 builder 메서드의 접근 제어자를 `public`에서 `private`으로 변경하였습니다.
- 불필요한 외부 생성 경로를 차단하여, 생성자 또는 정적 팩토리 메서드를 통한 일관된 객체 생성을 유도합니다.

## 🛠 작업 내용
- [x] entity builder 메서드의 접근 제어자 private 로 변경

## 🔍 관련 이슈
Closes #150 

## 📸 스크린샷 (Optional)
<img width="898" height="203" alt="image" src="https://github.com/user-attachments/assets/738a5985-3c3d-49cf-961e-7495e95a65d7" />

## 📚 레퍼런스 (Optional)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved formatting for better readability in some user and authentication request/response screens.
  * Updated internal object creation methods to enhance consistency and enforce best practices across several features. No visible changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->